### PR TITLE
Implement #2: Fetch GitHub Projects items

### DIFF
--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -8,7 +8,7 @@
 
 | 用途 | ライブラリ |
 |---|---|
-| GitHub API クライアント | [go-github](https://github.com/google/go-github) |
+| GitHub GraphQL API | [githubv4](https://github.com/shurcooL/githubv4) |
 | 環境変数 (.env) | [godotenv](https://github.com/joho/godotenv) |
 
 ## ディレクトリ構成（予定）

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/douhashi/gh-project-promoter
 
 go 1.24.1
 
-require github.com/joho/godotenv v1.5.1
-
 require (
-	github.com/google/go-github/v82 v82.0.0
-	github.com/google/go-querystring v1.2.0 // indirect
+	github.com/joho/godotenv v1.5.1
+	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
+	golang.org/x/oauth2 v0.24.0
 )
+
+require github.com/shurcooL/graphql v0.0.0-20240915155400-7ee5256398cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,10 @@
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v82 v82.0.0 h1:OH09ESON2QwKCUVMYmMcVu1IFKFoaZHwqYaUtr/MVfk=
-github.com/google/go-github/v82 v82.0.0/go.mod h1:hQ6Xo0VKfL8RZ7z1hSfB4fvISg0QqHOqe9BP0qo+WvM=
-github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
-github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed h1:KT7hI8vYXgU0s2qaMkrfq9tCA1w/iEPgfredVP+4Tzw=
+github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
+github.com/shurcooL/graphql v0.0.0-20240915155400-7ee5256398cf h1:o1uxfymjZ7jZ4MsgCErcwWGtVKSiNAXtS59Lhs6uI/g=
+github.com/shurcooL/graphql v0.0.0-20240915155400-7ee5256398cf/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
+golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
+golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,3 +1,81 @@
 package cache
 
-// placeholder for cache management
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+const (
+	dirName  = "ghpp"
+	fileName = "items.json"
+)
+
+// CacheData holds cached project items with a timestamp.
+type CacheData struct {
+	FetchedAt time.Time            `json:"fetched_at"`
+	Items     []github.ProjectItem `json:"items"`
+}
+
+// Dir returns the cache directory path (~/.local/share/ghpp/).
+func Dir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "share", dirName), nil
+}
+
+// Store writes the given items to the cache file as JSON.
+func Store(items []github.ProjectItem) error {
+	dir, err := Dir()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	data := CacheData{
+		FetchedAt: time.Now(),
+		Items:     items,
+	}
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache data: %w", err)
+	}
+
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return fmt.Errorf("failed to write cache file: %w", err)
+	}
+
+	return nil
+}
+
+// Load reads the cache file and returns the cached data.
+func Load() (*CacheData, error) {
+	dir, err := Dir()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(dir, fileName)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cache file: %w", err)
+	}
+
+	var data CacheData
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cache data: %w", err)
+	}
+
+	return &data, nil
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,126 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+func TestStoreAndLoad(t *testing.T) {
+	// Override HOME to use a temp directory
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	items := []github.ProjectItem{
+		{ID: "PVTI_001", Title: "Issue 1", URL: "https://example.com/1", Status: "Ready"},
+		{ID: "PVTI_002", Title: "Issue 2", URL: "https://example.com/2", Status: "Backlog"},
+	}
+
+	if err := Store(items); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// Verify file was created
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("Dir() error: %v", err)
+	}
+	path := filepath.Join(dir, fileName)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("cache file was not created")
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if got.FetchedAt.IsZero() {
+		t.Error("FetchedAt should not be zero")
+	}
+
+	if len(got.Items) != len(items) {
+		t.Fatalf("got %d items, want %d", len(got.Items), len(items))
+	}
+
+	for i, item := range got.Items {
+		if item.ID != items[i].ID {
+			t.Errorf("items[%d].ID = %q, want %q", i, item.ID, items[i].ID)
+		}
+		if item.Title != items[i].Title {
+			t.Errorf("items[%d].Title = %q, want %q", i, item.Title, items[i].Title)
+		}
+		if item.URL != items[i].URL {
+			t.Errorf("items[%d].URL = %q, want %q", i, item.URL, items[i].URL)
+		}
+		if item.Status != items[i].Status {
+			t.Errorf("items[%d].Status = %q, want %q", i, item.Status, items[i].Status)
+		}
+	}
+}
+
+func TestDirectoryAutoCreation(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	items := []github.ProjectItem{
+		{ID: "PVTI_001", Title: "Test", URL: "https://example.com/1", Status: "Todo"},
+	}
+
+	// Directory should not exist yet
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("Dir() error: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatal("cache directory should not exist before Store")
+	}
+
+	if err := Store(items); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// Directory should now exist
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("cache directory was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("cache path should be a directory")
+	}
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("Dir() error: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll error: %v", err)
+	}
+
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, []byte("not valid json"), 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	_, err = Load()
+	if err == nil {
+		t.Fatal("Load() should return error for invalid JSON")
+	}
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() should return error when file does not exist")
+	}
+}

--- a/internal/cmd/fetch.go
+++ b/internal/cmd/fetch.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/douhashi/gh-project-promoter/internal/cache"
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// RunFetch fetches project items via the GitHub API and stores them in the local cache.
+func RunFetch(ctx context.Context, cfg *config.Config, fetcher github.ItemFetcher) error {
+	items, err := fetcher.FetchProjectItems(ctx, cfg.Owner, cfg.ProjectNumber)
+	if err != nil {
+		return fmt.Errorf("failed to fetch project items: %w", err)
+	}
+
+	if err := cache.Store(items); err != nil {
+		return fmt.Errorf("failed to store cache: %w", err)
+	}
+
+	fmt.Printf("Fetched %d items\n", len(items))
+	return nil
+}

--- a/internal/cmd/fetch_test.go
+++ b/internal/cmd/fetch_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// mockFetcher implements github.ItemFetcher for testing.
+type mockFetcher struct {
+	items []github.ProjectItem
+	err   error
+}
+
+func (m *mockFetcher) FetchProjectItems(_ context.Context, _ string, _ int) ([]github.ProjectItem, error) {
+	return m.items, m.err
+}
+
+func TestRunFetch(t *testing.T) {
+	tests := []struct {
+		name    string
+		fetcher *mockFetcher
+		wantErr bool
+	}{
+		{
+			name: "success",
+			fetcher: &mockFetcher{
+				items: []github.ProjectItem{
+					{ID: "PVTI_001", Title: "Issue 1", URL: "https://example.com/1", Status: "Ready"},
+					{ID: "PVTI_002", Title: "Issue 2", URL: "https://example.com/2", Status: "Backlog"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty items",
+			fetcher: &mockFetcher{
+				items: []github.ProjectItem{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "fetch error",
+			fetcher: &mockFetcher{
+				err: errors.New("API error"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use temp HOME for cache
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+
+			cfg := &config.Config{
+				Owner:         "testowner",
+				ProjectNumber: 1,
+			}
+
+			err := RunFetch(context.Background(), cfg, tt.fetcher)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,10 +1,193 @@
 package github
 
 import (
-	gh "github.com/google/go-github/v82/github"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
 )
 
-// Client wraps the GitHub API client.
+// ItemFetcher abstracts fetching project items for testability.
+type ItemFetcher interface {
+	FetchProjectItems(ctx context.Context, owner string, projectNumber int) ([]ProjectItem, error)
+}
+
+// Client wraps the GitHub GraphQL API client.
 type Client struct {
-	inner *gh.Client //nolint:unused // will be used when API methods are implemented
+	inner *githubv4.Client
+}
+
+// NewClient creates a Client authenticated with the given token.
+func NewClient(token string) *Client {
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(context.Background(), src)
+	return &Client{inner: githubv4.NewClient(httpClient)}
+}
+
+// newClientWithHTTP creates a Client backed by the given http.Client (for testing).
+func newClientWithHTTP(httpClient *http.Client) *Client {
+	return &Client{inner: githubv4.NewClient(httpClient)}
+}
+
+// projectV2Query is the GraphQL query struct for fetching project items.
+// It works for both user and organization owners via the ownerType parameter.
+type projectV2Query struct {
+	User struct {
+		ProjectV2 struct {
+			Items struct {
+				TotalCount int
+				PageInfo   struct {
+					HasNextPage bool
+					EndCursor   githubv4.String
+				}
+				Nodes []itemNode
+			} `graphql:"items(first: 100, after: $cursor)"`
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"user(login: $owner)"`
+}
+
+type orgProjectV2Query struct {
+	Organization struct {
+		ProjectV2 struct {
+			Items struct {
+				TotalCount int
+				PageInfo   struct {
+					HasNextPage bool
+					EndCursor   githubv4.String
+				}
+				Nodes []itemNode
+			} `graphql:"items(first: 100, after: $cursor)"`
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"organization(login: $owner)"`
+}
+
+type itemNode struct {
+	ID          string
+	FieldValues struct {
+		Nodes []fieldValueNode
+	} `graphql:"fieldValues(first: 20)"`
+	Content itemContent `graphql:"content"`
+}
+
+type fieldValueNode struct {
+	TypeName           string `graphql:"__typename"`
+	ProjectV2ItemField struct {
+		Name  string
+		Field struct {
+			TypeName              string `graphql:"__typename"`
+			ProjectV2SingleSelect struct {
+				Name string
+			} `graphql:"... on ProjectV2SingleSelectField"`
+		}
+	} `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+}
+
+type itemContent struct {
+	TypeName string `graphql:"__typename"`
+	Issue    struct {
+		Title string
+		URL   string `graphql:"url"`
+	} `graphql:"... on Issue"`
+	PullRequest struct {
+		Title string
+		URL   string `graphql:"url"`
+	} `graphql:"... on PullRequest"`
+}
+
+// FetchProjectItems retrieves all items from a GitHub ProjectV2.
+// It first tries as a user project; if that fails, it retries as an organization project.
+func (c *Client) FetchProjectItems(ctx context.Context, owner string, projectNumber int) ([]ProjectItem, error) {
+	items, err := c.fetchUserProjectItems(ctx, owner, projectNumber)
+	if err == nil {
+		return items, nil
+	}
+
+	orgItems, orgErr := c.fetchOrgProjectItems(ctx, owner, projectNumber)
+	if orgErr != nil {
+		return nil, fmt.Errorf("failed to fetch project items (tried user and org): user: %w, org: %v", err, orgErr)
+	}
+	return orgItems, nil
+}
+
+func (c *Client) fetchUserProjectItems(ctx context.Context, owner string, projectNumber int) ([]ProjectItem, error) {
+	var allItems []ProjectItem
+	var cursor *githubv4.String
+
+	for {
+		var q projectV2Query
+		variables := map[string]interface{}{
+			"owner":  githubv4.String(owner),
+			"number": githubv4.Int(projectNumber),
+			"cursor": cursor,
+		}
+
+		if err := c.inner.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("failed to query user project: %w", err)
+		}
+
+		for _, node := range q.User.ProjectV2.Items.Nodes {
+			allItems = append(allItems, toProjectItem(node))
+		}
+
+		if !q.User.ProjectV2.Items.PageInfo.HasNextPage {
+			break
+		}
+		cursor = &q.User.ProjectV2.Items.PageInfo.EndCursor
+	}
+
+	return allItems, nil
+}
+
+func (c *Client) fetchOrgProjectItems(ctx context.Context, owner string, projectNumber int) ([]ProjectItem, error) {
+	var allItems []ProjectItem
+	var cursor *githubv4.String
+
+	for {
+		var q orgProjectV2Query
+		variables := map[string]interface{}{
+			"owner":  githubv4.String(owner),
+			"number": githubv4.Int(projectNumber),
+			"cursor": cursor,
+		}
+
+		if err := c.inner.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("failed to query org project: %w", err)
+		}
+
+		for _, node := range q.Organization.ProjectV2.Items.Nodes {
+			allItems = append(allItems, toProjectItem(node))
+		}
+
+		if !q.Organization.ProjectV2.Items.PageInfo.HasNextPage {
+			break
+		}
+		cursor = &q.Organization.ProjectV2.Items.PageInfo.EndCursor
+	}
+
+	return allItems, nil
+}
+
+func toProjectItem(node itemNode) ProjectItem {
+	item := ProjectItem{ID: node.ID}
+
+	switch node.Content.TypeName {
+	case "Issue":
+		item.Title = node.Content.Issue.Title
+		item.URL = node.Content.Issue.URL
+	case "PullRequest":
+		item.Title = node.Content.PullRequest.Title
+		item.URL = node.Content.PullRequest.URL
+	}
+
+	for _, fv := range node.FieldValues.Nodes {
+		if fv.TypeName == "ProjectV2ItemFieldSingleSelectValue" &&
+			fv.ProjectV2ItemField.Field.ProjectV2SingleSelect.Name == "Status" {
+			item.Status = fv.ProjectV2ItemField.Name
+			break
+		}
+	}
+
+	return item
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,283 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// graphqlResponse is a helper to build JSON responses for the mock server.
+type graphqlResponse struct {
+	Data   interface{} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+func TestFetchProjectItems_User(t *testing.T) {
+	resp := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 3,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": false,
+							"endCursor":   "",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id": "PVTI_001",
+								"fieldValues": map[string]interface{}{
+									"nodes": []interface{}{
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldTextValue",
+										},
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldSingleSelectValue",
+											"name":       "Ready",
+											"field": map[string]interface{}{
+												"__typename": "ProjectV2SingleSelectField",
+												"name":       "Status",
+											},
+										},
+									},
+								},
+								"content": map[string]interface{}{
+									"__typename": "Issue",
+									"title":      "Sample Issue 2",
+									"url":        "https://github.com/douhashi/gh-project-promoter/issues/7",
+								},
+							},
+							map[string]interface{}{
+								"id": "PVTI_002",
+								"fieldValues": map[string]interface{}{
+									"nodes": []interface{}{
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldSingleSelectValue",
+											"name":       "Backlog",
+											"field": map[string]interface{}{
+												"__typename": "ProjectV2SingleSelectField",
+												"name":       "Status",
+											},
+										},
+									},
+								},
+								"content": map[string]interface{}{
+									"__typename": "Issue",
+									"title":      "Sample Issue 1",
+									"url":        "https://github.com/douhashi/gh-project-promoter/issues/6",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := newClientWithHTTP(srv.Client())
+	client.inner = newTestGitHubV4Client(srv.URL, srv.Client())
+
+	items, err := client.FetchProjectItems(context.Background(), "testuser", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	tests := []struct {
+		idx    int
+		id     string
+		title  string
+		url    string
+		status string
+	}{
+		{0, "PVTI_001", "Sample Issue 2", "https://github.com/douhashi/gh-project-promoter/issues/7", "Ready"},
+		{1, "PVTI_002", "Sample Issue 1", "https://github.com/douhashi/gh-project-promoter/issues/6", "Backlog"},
+	}
+
+	for _, tt := range tests {
+		item := items[tt.idx]
+		if item.ID != tt.id {
+			t.Errorf("items[%d].ID = %q, want %q", tt.idx, item.ID, tt.id)
+		}
+		if item.Title != tt.title {
+			t.Errorf("items[%d].Title = %q, want %q", tt.idx, item.Title, tt.title)
+		}
+		if item.URL != tt.url {
+			t.Errorf("items[%d].URL = %q, want %q", tt.idx, item.URL, tt.url)
+		}
+		if item.Status != tt.status {
+			t.Errorf("items[%d].Status = %q, want %q", tt.idx, item.Status, tt.status)
+		}
+	}
+}
+
+func TestFetchProjectItems_Pagination(t *testing.T) {
+	var callCount atomic.Int32
+
+	page1 := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 2,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": true,
+							"endCursor":   "cursor1",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id":          "PVTI_P1",
+								"fieldValues": map[string]interface{}{"nodes": []interface{}{}},
+								"content":     map[string]interface{}{"__typename": "Issue", "title": "Issue 1", "url": "https://example.com/1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	page2 := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 2,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": false,
+							"endCursor":   "",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id":          "PVTI_P2",
+								"fieldValues": map[string]interface{}{"nodes": []interface{}{}},
+								"content":     map[string]interface{}{"__typename": "Issue", "title": "Issue 2", "url": "https://example.com/2"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := callCount.Add(1)
+		var resp graphqlResponse
+		if n == 1 {
+			resp = page1
+		} else {
+			resp = page2
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	items, err := client.FetchProjectItems(context.Background(), "testuser", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	if items[0].ID != "PVTI_P1" {
+		t.Errorf("items[0].ID = %q, want PVTI_P1", items[0].ID)
+	}
+	if items[1].ID != "PVTI_P2" {
+		t.Errorf("items[1].ID = %q, want PVTI_P2", items[1].ID)
+	}
+}
+
+func TestFetchProjectItems_OrgFallback(t *testing.T) {
+	var callCount atomic.Int32
+
+	userErrResp := graphqlResponse{
+		Errors: []struct {
+			Message string `json:"message"`
+		}{{Message: "Could not resolve to a User"}},
+	}
+
+	orgResp := graphqlResponse{
+		Data: map[string]interface{}{
+			"organization": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 1,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": false,
+							"endCursor":   "",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id":          "PVTI_ORG1",
+								"fieldValues": map[string]interface{}{"nodes": []interface{}{}},
+								"content":     map[string]interface{}{"__typename": "Issue", "title": "Org Issue", "url": "https://example.com/org/1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := callCount.Add(1)
+		if n == 1 {
+			// First call: user query fails
+			if err := json.NewEncoder(w).Encode(userErrResp); err != nil {
+				t.Errorf("failed to encode response: %v", err)
+			}
+		} else {
+			// Second call: org query succeeds
+			if err := json.NewEncoder(w).Encode(orgResp); err != nil {
+				t.Errorf("failed to encode response: %v", err)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	items, err := client.FetchProjectItems(context.Background(), "my-org", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+
+	if items[0].Title != "Org Issue" {
+		t.Errorf("items[0].Title = %q, want %q", items[0].Title, "Org Issue")
+	}
+}
+
+// newTestGitHubV4Client creates a githubv4.Client pointing at a test server.
+func newTestGitHubV4Client(url string, httpClient *http.Client) *githubv4.Client {
+	return githubv4.NewEnterpriseClient(url+"/graphql", httpClient)
+}

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,0 +1,9 @@
+package github
+
+// ProjectItem represents a single item in a GitHub Project.
+type ProjectItem struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	URL    string `json:"url"`
+	Status string `json:"status"`
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"
+
+	"github.com/douhashi/gh-project-promoter/internal/cmd"
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
 )
 
 func main() {
@@ -14,5 +19,28 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("gh-project-promoter")
+
+	if len(os.Args) < 2 {
+		fmt.Println("gh-project-promoter")
+		fmt.Println("Usage: gh-project-promoter <command>")
+		fmt.Println("Commands: fetch")
+		return
+	}
+
+	switch os.Args[1] {
+	case "fetch":
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		client := github.NewClient(cfg.Token)
+		if err := cmd.RunFetch(context.Background(), cfg, client); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Closes #2

## 変更内容

GitHub Projects V2 API (GraphQL) にアクセスし、Project 内の Item 一覧を取得してローカルにキャッシュする `fetch` サブコマンドを実装。

- **`internal/github/`**: `shurcooL/githubv4` ベースの GraphQL クライアント。User/Org フォールバック、cursor ベースページネーション対応
- **`internal/cache/`**: `~/.local/share/ghpp/items.json` への JSON キャッシュ読み書き
- **`internal/cmd/`**: `RunFetch` コマンドロジック（`ItemFetcher` インターフェースでテスト可能）
- **`main.go`**: `fetch` サブコマンドルーティング追加
- **`docs/development/guideline.md`**: 技術スタックを `githubv4` に更新

## レビュー結果
内部レビュー通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)