### PR TITLE
Implement #3: Promote command for issue status promotion

### DIFF
--- a/internal/cmd/promote.go
+++ b/internal/cmd/promote.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/douhashi/gh-project-promoter/internal/cache"
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+	"github.com/douhashi/gh-project-promoter/internal/promote"
+)
+
+// RunPromote loads cached items, runs the promotion logic, and prints the results as JSON.
+func RunPromote(ctx context.Context, cfg *config.Config, promoter github.ItemPromoter) error {
+	data, err := cache.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load cache: %w", err)
+	}
+
+	results, err := promote.Run(ctx, cfg, data.Items, promoter)
+	if err != nil {
+		return fmt.Errorf("failed to run promote: %w", err)
+	}
+
+	out, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	fmt.Println(string(out))
+	return nil
+}

--- a/internal/cmd/promote_test.go
+++ b/internal/cmd/promote_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/douhashi/gh-project-promoter/internal/cache"
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// mockPromoter implements github.ItemPromoter for testing.
+type mockPromoter struct {
+	meta      *github.ProjectMeta
+	metaErr   error
+	updateErr error
+}
+
+func (m *mockPromoter) FetchProjectMeta(_ context.Context, _ string, _ int) (*github.ProjectMeta, error) {
+	return m.meta, m.metaErr
+}
+
+func (m *mockPromoter) UpdateItemStatus(_ context.Context, _ *github.ProjectMeta, _ string, _ string) error {
+	return m.updateErr
+}
+
+func TestRunPromote(t *testing.T) {
+	defaultMeta := &github.ProjectMeta{
+		ProjectID: "PVT_001",
+		FieldID:   "PVTSSF_001",
+		Options: map[string]string{
+			"Backlog":     "opt1",
+			"Plan":        "opt2",
+			"Ready":       "opt3",
+			"In progress": "opt4",
+			"Done":        "opt5",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		items    []github.ProjectItem
+		promoter *mockPromoter
+		wantErr  bool
+	}{
+		{
+			name: "success with items",
+			items: []github.ProjectItem{
+				{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+			},
+			promoter: &mockPromoter{meta: defaultMeta},
+			wantErr:  false,
+		},
+		{
+			name:     "success with empty items",
+			items:    []github.ProjectItem{},
+			promoter: &mockPromoter{meta: defaultMeta},
+			wantErr:  false,
+		},
+		{
+			name: "promoter error",
+			items: []github.ProjectItem{
+				{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+			},
+			promoter: &mockPromoter{metaErr: errors.New("API error")},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+
+			// Store items in cache
+			if err := cache.Store(tt.items); err != nil {
+				t.Fatalf("failed to store cache: %v", err)
+			}
+
+			cfg := &config.Config{
+				Owner:         "testowner",
+				ProjectNumber: 1,
+				StatusInbox:   "Backlog",
+				StatusPlan:    "Plan",
+				StatusReady:   "Ready",
+				StatusDoing:   "In progress",
+			}
+
+			err := RunPromote(context.Background(), cfg, tt.promoter)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunPromote_NoCacheFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg := &config.Config{
+		Owner:         "testowner",
+		ProjectNumber: 1,
+	}
+
+	mp := &mockPromoter{
+		meta: &github.ProjectMeta{
+			ProjectID: "PVT_001",
+			FieldID:   "PVTSSF_001",
+			Options:   map[string]string{},
+		},
+	}
+
+	err := RunPromote(context.Background(), cfg, mp)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,6 +14,12 @@ type ItemFetcher interface {
 	FetchProjectItems(ctx context.Context, owner string, projectNumber int) ([]ProjectItem, error)
 }
 
+// ItemPromoter abstracts promoting project items for testability.
+type ItemPromoter interface {
+	FetchProjectMeta(ctx context.Context, owner string, projectNumber int) (*ProjectMeta, error)
+	UpdateItemStatus(ctx context.Context, meta *ProjectMeta, itemID string, statusName string) error
+}
+
 // Client wraps the GitHub GraphQL API client.
 type Client struct {
 	inner *githubv4.Client
@@ -167,6 +173,127 @@ func (c *Client) fetchOrgProjectItems(ctx context.Context, owner string, project
 	}
 
 	return allItems, nil
+}
+
+// statusFieldNode represents the Status field inline fragment in project metadata queries.
+type statusFieldNode struct {
+	TypeName                   string `graphql:"__typename"`
+	ProjectV2SingleSelectField struct {
+		ID      string
+		Options []struct {
+			ID   string
+			Name string
+		}
+	} `graphql:"... on ProjectV2SingleSelectField"`
+}
+
+// projectMetaQuery is the GraphQL query struct for fetching project metadata (user).
+type projectMetaQuery struct {
+	User struct {
+		ProjectV2 struct {
+			ID    string
+			Field statusFieldNode `graphql:"field(name: \"Status\")"`
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"user(login: $owner)"`
+}
+
+// orgProjectMetaQuery is the GraphQL query struct for fetching project metadata (org).
+type orgProjectMetaQuery struct {
+	Organization struct {
+		ProjectV2 struct {
+			ID    string
+			Field statusFieldNode `graphql:"field(name: \"Status\")"`
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"organization(login: $owner)"`
+}
+
+// updateItemStatusMutation is the GraphQL mutation struct for updating an item's status.
+type updateItemStatusMutation struct {
+	UpdateProjectV2ItemFieldValue struct {
+		ProjectV2Item struct {
+			ID string
+		}
+	} `graphql:"updateProjectV2ItemFieldValue(input: $input)"`
+}
+
+// FetchProjectMeta retrieves project-level metadata (ID, Status field ID, and options).
+// It first tries as a user project; if that fails, it retries as an organization project.
+func (c *Client) FetchProjectMeta(ctx context.Context, owner string, projectNumber int) (*ProjectMeta, error) {
+	meta, err := c.fetchUserProjectMeta(ctx, owner, projectNumber)
+	if err == nil {
+		return meta, nil
+	}
+
+	orgMeta, orgErr := c.fetchOrgProjectMeta(ctx, owner, projectNumber)
+	if orgErr != nil {
+		return nil, fmt.Errorf("failed to fetch project meta (tried user and org): user: %w, org: %v", err, orgErr)
+	}
+	return orgMeta, nil
+}
+
+func (c *Client) fetchUserProjectMeta(ctx context.Context, owner string, projectNumber int) (*ProjectMeta, error) {
+	var q projectMetaQuery
+	variables := map[string]interface{}{
+		"owner":  githubv4.String(owner),
+		"number": githubv4.Int(projectNumber),
+	}
+
+	if err := c.inner.Query(ctx, &q, variables); err != nil {
+		return nil, fmt.Errorf("failed to query user project meta: %w", err)
+	}
+
+	return toProjectMeta(q.User.ProjectV2.ID, q.User.ProjectV2.Field), nil
+}
+
+func (c *Client) fetchOrgProjectMeta(ctx context.Context, owner string, projectNumber int) (*ProjectMeta, error) {
+	var q orgProjectMetaQuery
+	variables := map[string]interface{}{
+		"owner":  githubv4.String(owner),
+		"number": githubv4.Int(projectNumber),
+	}
+
+	if err := c.inner.Query(ctx, &q, variables); err != nil {
+		return nil, fmt.Errorf("failed to query org project meta: %w", err)
+	}
+
+	return toProjectMeta(q.Organization.ProjectV2.ID, q.Organization.ProjectV2.Field), nil
+}
+
+func toProjectMeta(projectID string, field statusFieldNode) *ProjectMeta {
+	ssf := field.ProjectV2SingleSelectField
+	options := make(map[string]string, len(ssf.Options))
+	for _, opt := range ssf.Options {
+		options[opt.Name] = opt.ID
+	}
+	return &ProjectMeta{
+		ProjectID: projectID,
+		FieldID:   ssf.ID,
+		Options:   options,
+	}
+}
+
+// UpdateItemStatus updates the Status field of a project item to the given status name.
+func (c *Client) UpdateItemStatus(ctx context.Context, meta *ProjectMeta, itemID string, statusName string) error {
+	optionID, ok := meta.Options[statusName]
+	if !ok {
+		return fmt.Errorf("unknown status %q: not found in project options", statusName)
+	}
+
+	var m updateItemStatusMutation
+	input := githubv4.UpdateProjectV2ItemFieldValueInput{
+		ProjectID: githubv4.ID(meta.ProjectID),
+		ItemID:    githubv4.ID(itemID),
+		FieldID:   githubv4.ID(meta.FieldID),
+		Value: githubv4.ProjectV2FieldValue{
+			SingleSelectOptionID: githubv4.NewString(githubv4.String(optionID)),
+		},
+	}
+
+	if err := c.inner.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("failed to update item status to %q: %w", statusName, err)
+	}
+
+	return nil
 }
 
 func toProjectItem(node itemNode) ProjectItem {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -277,6 +277,169 @@ func TestFetchProjectItems_OrgFallback(t *testing.T) {
 	}
 }
 
+func TestFetchProjectMeta_User(t *testing.T) {
+	resp := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"id": "PVT_001",
+					"field": map[string]interface{}{
+						"__typename": "ProjectV2SingleSelectField",
+						"id":         "PVTSSF_001",
+						"options": []interface{}{
+							map[string]interface{}{"id": "opt1", "name": "Backlog"},
+							map[string]interface{}{"id": "opt2", "name": "Ready"},
+							map[string]interface{}{"id": "opt3", "name": "In progress"},
+							map[string]interface{}{"id": "opt4", "name": "Done"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	meta, err := client.FetchProjectMeta(context.Background(), "testuser", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if meta.ProjectID != "PVT_001" {
+		t.Errorf("ProjectID = %q, want %q", meta.ProjectID, "PVT_001")
+	}
+	if meta.FieldID != "PVTSSF_001" {
+		t.Errorf("FieldID = %q, want %q", meta.FieldID, "PVTSSF_001")
+	}
+	if len(meta.Options) != 4 {
+		t.Fatalf("expected 4 options, got %d", len(meta.Options))
+	}
+	if meta.Options["Backlog"] != "opt1" {
+		t.Errorf("Options[Backlog] = %q, want %q", meta.Options["Backlog"], "opt1")
+	}
+	if meta.Options["Ready"] != "opt2" {
+		t.Errorf("Options[Ready] = %q, want %q", meta.Options["Ready"], "opt2")
+	}
+}
+
+func TestFetchProjectMeta_OrgFallback(t *testing.T) {
+	var callCount atomic.Int32
+
+	userErrResp := graphqlResponse{
+		Errors: []struct {
+			Message string `json:"message"`
+		}{{Message: "Could not resolve to a User"}},
+	}
+
+	orgResp := graphqlResponse{
+		Data: map[string]interface{}{
+			"organization": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"id": "PVT_ORG1",
+					"field": map[string]interface{}{
+						"__typename": "ProjectV2SingleSelectField",
+						"id":         "PVTSSF_ORG1",
+						"options": []interface{}{
+							map[string]interface{}{"id": "orgopt1", "name": "Todo"},
+							map[string]interface{}{"id": "orgopt2", "name": "Done"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := callCount.Add(1)
+		if n == 1 {
+			if err := json.NewEncoder(w).Encode(userErrResp); err != nil {
+				t.Errorf("failed to encode response: %v", err)
+			}
+		} else {
+			if err := json.NewEncoder(w).Encode(orgResp); err != nil {
+				t.Errorf("failed to encode response: %v", err)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	meta, err := client.FetchProjectMeta(context.Background(), "my-org", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if meta.ProjectID != "PVT_ORG1" {
+		t.Errorf("ProjectID = %q, want %q", meta.ProjectID, "PVT_ORG1")
+	}
+	if meta.Options["Todo"] != "orgopt1" {
+		t.Errorf("Options[Todo] = %q, want %q", meta.Options["Todo"], "orgopt1")
+	}
+}
+
+func TestUpdateItemStatus(t *testing.T) {
+	resp := graphqlResponse{
+		Data: map[string]interface{}{
+			"updateProjectV2ItemFieldValue": map[string]interface{}{
+				"projectV2Item": map[string]interface{}{
+					"id": "PVTI_001",
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	meta := &ProjectMeta{
+		ProjectID: "PVT_001",
+		FieldID:   "PVTSSF_001",
+		Options:   map[string]string{"Ready": "opt2", "In progress": "opt3"},
+	}
+
+	err := client.UpdateItemStatus(context.Background(), meta, "PVTI_001", "Ready")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateItemStatus_InvalidStatus(t *testing.T) {
+	client := &Client{inner: nil} // inner not needed since we error before API call
+
+	meta := &ProjectMeta{
+		ProjectID: "PVT_001",
+		FieldID:   "PVTSSF_001",
+		Options:   map[string]string{"Ready": "opt2"},
+	}
+
+	err := client.UpdateItemStatus(context.Background(), meta, "PVTI_001", "NonExistent")
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	want := `unknown status "NonExistent": not found in project options`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
 // newTestGitHubV4Client creates a githubv4.Client pointing at a test server.
 func newTestGitHubV4Client(url string, httpClient *http.Client) *githubv4.Client {
 	return githubv4.NewEnterpriseClient(url+"/graphql", httpClient)

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -7,3 +7,18 @@ type ProjectItem struct {
 	URL    string `json:"url"`
 	Status string `json:"status"`
 }
+
+// ProjectMeta holds project-level metadata needed for mutations.
+type ProjectMeta struct {
+	ProjectID string
+	FieldID   string            // Status フィールドの ID
+	Options   map[string]string // ステータス名 -> Option ID のマップ
+}
+
+// PromoteResult represents the outcome of a single promote attempt.
+type PromoteResult struct {
+	Item     ProjectItem `json:"item"`
+	Action   string      `json:"action"` // "promoted" or "skipped"
+	Reason   string      `json:"reason,omitempty"`
+	ToStatus string      `json:"to_status,omitempty"`
+}

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -1,3 +1,122 @@
 package promote
 
-// placeholder for promote logic
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// Run executes both promotion phases and returns all results.
+func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, promoter github.ItemPromoter) ([]github.PromoteResult, error) {
+	meta, err := promoter.FetchProjectMeta(ctx, cfg.Owner, cfg.ProjectNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch project meta: %w", err)
+	}
+
+	planResults, err := planPhase(ctx, cfg, items, meta, promoter)
+	if err != nil {
+		return nil, fmt.Errorf("plan phase failed: %w", err)
+	}
+
+	doingResults, err := doingPhase(ctx, cfg, items, meta, promoter)
+	if err != nil {
+		return nil, fmt.Errorf("doing phase failed: %w", err)
+	}
+
+	return append(planResults, doingResults...), nil
+}
+
+func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) ([]github.PromoteResult, error) {
+	var results []github.PromoteResult
+	promoted := 0
+
+	for _, item := range items {
+		if item.Status != cfg.StatusInbox {
+			continue
+		}
+
+		if cfg.PlanLimit > 0 && promoted >= cfg.PlanLimit {
+			results = append(results, github.PromoteResult{
+				Item:   item,
+				Action: "skipped",
+				Reason: "plan limit reached",
+			})
+			continue
+		}
+
+		if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusPlan); err != nil {
+			return nil, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusPlan, err)
+		}
+
+		results = append(results, github.PromoteResult{
+			Item:     item,
+			Action:   "promoted",
+			ToStatus: cfg.StatusPlan,
+		})
+		promoted++
+	}
+
+	return results, nil
+}
+
+func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) ([]github.PromoteResult, error) {
+	var results []github.PromoteResult
+
+	// Build set of repos that already have a doing item.
+	doingRepos := make(map[string]bool)
+	for _, item := range items {
+		if item.Status != cfg.StatusDoing {
+			continue
+		}
+		repo := extractRepo(item.URL)
+		if repo != "" {
+			doingRepos[repo] = true
+		}
+	}
+
+	for _, item := range items {
+		if item.Status != cfg.StatusReady {
+			continue
+		}
+
+		repo := extractRepo(item.URL)
+		if doingRepos[repo] {
+			results = append(results, github.PromoteResult{
+				Item:   item,
+				Action: "skipped",
+				Reason: "repository already has doing issue",
+			})
+			continue
+		}
+
+		if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusDoing); err != nil {
+			return nil, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusDoing, err)
+		}
+
+		results = append(results, github.PromoteResult{
+			Item:     item,
+			Action:   "promoted",
+			ToStatus: cfg.StatusDoing,
+		})
+		doingRepos[repo] = true
+	}
+
+	return results, nil
+}
+
+// extractRepo extracts "owner/repo" from a GitHub issue/PR URL.
+func extractRepo(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -1,0 +1,352 @@
+package promote
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// mockPromoter implements github.ItemPromoter for testing.
+type mockPromoter struct {
+	meta      *github.ProjectMeta
+	metaErr   error
+	updateErr error
+	updated   []updateCall
+}
+
+type updateCall struct {
+	ItemID     string
+	StatusName string
+}
+
+func (m *mockPromoter) FetchProjectMeta(_ context.Context, _ string, _ int) (*github.ProjectMeta, error) {
+	return m.meta, m.metaErr
+}
+
+func (m *mockPromoter) UpdateItemStatus(_ context.Context, _ *github.ProjectMeta, itemID string, statusName string) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.updated = append(m.updated, updateCall{ItemID: itemID, StatusName: statusName})
+	return nil
+}
+
+var defaultMeta = &github.ProjectMeta{
+	ProjectID: "PVT_001",
+	FieldID:   "PVTSSF_001",
+	Options: map[string]string{
+		"Backlog":     "opt1",
+		"Plan":        "opt2",
+		"Ready":       "opt3",
+		"In progress": "opt4",
+		"Done":        "opt5",
+	},
+}
+
+func defaultCfg() *config.Config {
+	return &config.Config{
+		Owner:         "testowner",
+		ProjectNumber: 1,
+		StatusInbox:   "Backlog",
+		StatusPlan:    "Plan",
+		StatusReady:   "Ready",
+		StatusDoing:   "In progress",
+		PlanLimit:     0,
+	}
+}
+
+func TestPlanPhase_InboxToPlan(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Done"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if promoted[0].Item.ID != "1" {
+		t.Errorf("promoted item ID = %q, want %q", promoted[0].Item.ID, "1")
+	}
+	if promoted[0].ToStatus != "Plan" {
+		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "Plan")
+	}
+}
+
+func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PlanLimit = 1
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog"},
+		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	skipped := filterByAction(results, "skipped")
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d", len(skipped))
+	}
+	if skipped[0].Reason != "plan limit reached" {
+		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "plan limit reached")
+	}
+}
+
+func TestPlanPhase_NoInboxItems(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Ready"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	planPromoted := 0
+	for _, r := range results {
+		if r.ToStatus == "Plan" {
+			planPromoted++
+		}
+	}
+	if planPromoted != 0 {
+		t.Errorf("expected 0 plan promotions, got %d", planPromoted)
+	}
+}
+
+func TestPlanPhase_PlanLimitZeroPromotesAll(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PlanLimit = 0
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog"},
+		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	if len(promoted) != 3 {
+		t.Fatalf("expected 3 promoted, got %d", len(promoted))
+	}
+}
+
+func TestDoingPhase_ReadyToDoing(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if promoted[0].ToStatus != "In progress" {
+		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "In progress")
+	}
+}
+
+func TestDoingPhase_SameRepoSecondSkipped(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	skipped := filterByAction(results, "skipped")
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+	if skipped[0].Reason != "repository already has doing issue" {
+		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "repository already has doing issue")
+	}
+}
+
+func TestDoingPhase_ExistingDoingRepoSkipped(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Doing Issue", URL: "https://github.com/owner/repo-a/issues/1", Status: "In progress"},
+		{ID: "2", Title: "Ready Issue", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	skipped := filterByAction(results, "skipped")
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+	if skipped[0].Item.ID != "2" {
+		t.Errorf("skipped item ID = %q, want %q", skipped[0].Item.ID, "2")
+	}
+}
+
+func TestDoingPhase_DifferentReposBothPromoted(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	if len(promoted) != 2 {
+		t.Fatalf("expected 2 promoted, got %d", len(promoted))
+	}
+}
+
+func TestExtractRepo(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "normal issue URL",
+			url:  "https://github.com/owner/repo/issues/123",
+			want: "owner/repo",
+		},
+		{
+			name: "pull request URL",
+			url:  "https://github.com/org/project/pull/456",
+			want: "org/project",
+		},
+		{
+			name: "invalid URL with no slash",
+			url:  "not-a-url",
+			want: "",
+		},
+		{
+			name: "too short path",
+			url:  "https://github.com/owner",
+			want: "",
+		},
+		{
+			name: "empty string",
+			url:  "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRepo(tt.url)
+			if got != tt.want {
+				t.Errorf("extractRepo(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRun_BothPhasesCombined(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PlanLimit = 1
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Inbox 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog"},
+		{ID: "2", Title: "Inbox 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Backlog"},
+		{ID: "3", Title: "Ready 1", URL: "https://github.com/owner/repo-c/issues/1", Status: "Ready"},
+		{ID: "4", Title: "Doing 1", URL: "https://github.com/owner/repo-d/issues/1", Status: "In progress"},
+	}
+
+	results, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := filterByAction(results, "promoted")
+	skipped := filterByAction(results, "skipped")
+	// Plan: 1 promoted (limit=1), 1 skipped. Doing: 1 promoted.
+	if len(promoted) != 2 {
+		t.Fatalf("expected 2 promoted, got %d", len(promoted))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+}
+
+func TestRun_APIError(t *testing.T) {
+	mp := &mockPromoter{
+		meta:      defaultMeta,
+		updateErr: errors.New("API error"),
+	}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+	}
+
+	_, err := Run(context.Background(), cfg, items, mp)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func TestRun_FetchMetaError(t *testing.T) {
+	mp := &mockPromoter{
+		metaErr: errors.New("meta error"),
+	}
+	cfg := defaultCfg()
+
+	_, err := Run(context.Background(), cfg, nil, mp)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func filterByAction(results []github.PromoteResult, action string) []github.PromoteResult {
+	var filtered []github.PromoteResult
+	for _, r := range results {
+		if r.Action == action {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("gh-project-promoter")
 		fmt.Println("Usage: gh-project-promoter <command>")
-		fmt.Println("Commands: fetch")
+		fmt.Println("Commands: fetch, promote")
 		return
 	}
 
@@ -36,6 +36,17 @@ func main() {
 		}
 		client := github.NewClient(cfg.Token)
 		if err := cmd.RunFetch(context.Background(), cfg, client); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	case "promote":
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		client := github.NewClient(cfg.Token)
+		if err := cmd.RunPromote(context.Background(), cfg, client); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Closes #3

## 変更内容

昇格ルールに基づく Issue ステータスの自動昇格を行う `promote` サブコマンドを実装。

- **`internal/github/`**: `ItemPromoter` IF、`FetchProjectMeta`(Project/Field/Option ID取得)、`UpdateItemStatus`(mutation)を追加
- **`internal/promote/`**: 計画フェーズ(inbox→plan, PlanLimit制御)、実行フェーズ(ready→doing, リポジトリ単位1つまで)の昇格ロジック
- **`internal/cmd/promote.go`**: `RunPromote` コマンドハンドラ（キャッシュ読込→昇格→JSON出力）
- **`main.go`**: `promote` サブコマンドルーティング追加

## レビュー結果
内部レビュー通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)