### PR TITLE
Implement #4: GoReleaser release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ gh-project-promoter
 # Temp
 .tmp/
 
+# GoReleaser
+dist/
+
 # Go
 *.exe
 *.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+version: 2
+
+builds:
+  - id: gh-project-promoter
+    main: .
+    binary: gh-project-promoter
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "Merge pull request"
+
+release:
+  github:
+    owner: douhashi
+    name: gh-project-promoter

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,4 @@
 go = "1.24.1"
 golangci-lint = "1.64.8"
 lefthook = "latest"
+goreleaser = "2"

--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -32,3 +32,25 @@
 go build -o gh-project-promoter .
 ./gh-project-promoter
 ```
+
+## リリース
+
+GoReleaser を使用してリリースする。
+
+### ローカルでのテストビルド
+
+```bash
+goreleaser release --snapshot --clean
+```
+
+### リリース手順
+
+1. バージョンタグを作成する: `git tag -a v1.0.0 -m "Release v1.0.0"`
+2. タグをプッシュする: `git push origin v1.0.0`
+3. GitHub Actions が自動的に GoReleaser を実行し、GitHub Releases にバイナリがアップロードされる
+
+### 設定ファイルの検証
+
+```bash
+goreleaser check
+```


### PR DESCRIPTION
Closes #4

## 変更内容

GoReleaser v2 を使用したリリースパイプラインを構築。

- **`.goreleaser.yml`**: マルチプラットフォームビルド設定 (linux/darwin/windows x amd64/arm64)、CGO_ENABLED=0、changelog フィルタ、checksums 生成
- **`.github/workflows/release.yml`**: `v*` タグ push 時に GoReleaser を実行し GitHub Releases にバイナリアップロード
- **`.gitignore`**: `dist/` 追加
- **`.mise.toml`**: `goreleaser = "2"` 追加
- **`docs/development/guideline.md`**: リリース手順セクション追加

## レビュー結果
内部レビュー通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)