### PR TITLE
Fix #16: Add graphql tag to ProjectV2Item field

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -212,7 +212,7 @@ type updateItemStatusMutation struct {
 	UpdateProjectV2ItemFieldValue struct {
 		ProjectV2Item struct {
 			ID string
-		}
+		} `graphql:"projectV2Item"`
 	} `graphql:"updateProjectV2ItemFieldValue(input: $input)"`
 }
 


### PR DESCRIPTION
Closes #16

## 変更内容

`shurcooL/graphql` ライブラリが `ProjectV2Item` を `projectV2item`（小文字 `i`）に自動変換してしまう問題を修正。`graphql:"projectV2Item"` タグを明示的に追加することで、`UpdateProjectV2ItemFieldValue` ミューテーションのエラーを解消。

### 変更ファイル

- `internal/github/client.go`: `updateItemStatusMutation` 構造体の `ProjectV2Item` フィールドに `graphql` タグを追加

## レビュー結果

内部レビュー通過済み