### PR TITLE
Implement #18: Remove version number from release archive name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ archives:
         formats:
           - zip
     name_template: >-
-      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+      {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Closes #18

## 変更内容
- `.goreleaser.yml` の `name_template` から `{{ .Version }}_` を削除
- アーカイブ名が `ghpp_linux_amd64.tar.gz` のようにバージョン番号なしになる
- ワンライナーでのダウンロード時にバージョンを意識する必要がなくなる

## レビュー結果
内部レビュー通過済み（テスト・lint・GoReleaser設定バリデーション全てパス）