### PR TITLE
Update GoReleaser config: rename repo, trim targets, add release rotation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,14 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete old releases (keep last 5)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release list --limit 100 --json tagName --jq '.[].tagName' \
+            | tail -n +6 \
+            | while read -r tag; do
+                echo "Deleting release and tag: $tag"
+                gh release delete "$tag" --yes --cleanup-tag
+              done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,10 +11,12 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: darwin
+        goarch: amd64
     flags:
       - -trimpath
     ldflags:
@@ -24,10 +26,6 @@ archives:
   - id: default
     formats:
       - tar.gz
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
     name_template: >-
       {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}
 
@@ -46,4 +44,4 @@ changelog:
 release:
   github:
     owner: douhashi
-    name: gh-project-promoter
+    name: ghpp


### PR DESCRIPTION
## Summary
- `release.github.name` を `gh-project-promoter` → `ghpp` に修正
- ビルドターゲットを linux/amd64, linux/arm64, darwin/arm64 の3つに絞り、Windows を削除
- リリース後に5世代より古いリリースとタグを自動削除するステップを追加

## Test plan
- [ ] `goreleaser check` で設定ファイルのバリデーション確認
- [ ] タグを打ってリリースワークフローが正常に動作することを確認
- [ ] 6世代目以降のリリースが自動削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)