### PR TITLE
Implement #25: Phase-grouped JSON output for promote

### DIFF
--- a/docs/business/model.md
+++ b/docs/business/model.md
@@ -34,3 +34,46 @@ Issue を `ready` から `doing` ステータスに昇格させる。
 - **リポジトリ単位で1つまで**: `doing` に昇格できるのは、各リポジトリにつき1つの Issue のみ
 - すでに同リポジトリの Issue が `doing` にある場合、昇格しない
 - リポジトリの判定は Issue URL から `owner/repository` を抽出して行う
+
+## 出力フォーマット
+
+Promote コマンドはフェーズ別サマリ付き JSON を出力する。
+
+```json
+{
+  "summary": {
+    "promoted": 4,
+    "skipped": 2,
+    "total": 6
+  },
+  "phases": {
+    "plan": {
+      "summary": {
+        "promoted": 3,
+        "skipped": 1,
+        "total": 4
+      },
+      "results": [
+        {
+          "item": { "id": "...", "title": "...", "url": "...", "status": "..." },
+          "action": "promoted",
+          "to_status": "Plan"
+        }
+      ]
+    },
+    "doing": {
+      "summary": {
+        "promoted": 1,
+        "skipped": 1,
+        "total": 2
+      },
+      "results": [...]
+    }
+  }
+}
+```
+
+- トップレベルの `summary` は全フェーズの合計値
+- `phases.plan` / `phases.doing` は常にキーが存在する（0件でも省略されない）
+- 各フェーズの `results` は0件の場合 `[]`（`null` ではない）
+- 各 result の `action` は `"promoted"` または `"skipped"`

--- a/internal/cmd/promote.go
+++ b/internal/cmd/promote.go
@@ -17,12 +17,12 @@ func RunPromote(ctx context.Context, cfg *config.Config, promoter github.ItemPro
 		return fmt.Errorf("failed to fetch project items: %w", err)
 	}
 
-	results, err := promote.Run(ctx, cfg, items, promoter)
+	resp, err := promote.Run(ctx, cfg, items, promoter)
 	if err != nil {
 		return fmt.Errorf("failed to run promote: %w", err)
 	}
 
-	out, err := json.MarshalIndent(results, "", "  ")
+	out, err := json.MarshalIndent(resp, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal results: %w", err)
 	}

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -22,3 +22,29 @@ type PromoteResult struct {
 	Reason   string      `json:"reason,omitempty"`
 	ToStatus string      `json:"to_status,omitempty"`
 }
+
+// PhaseSummary holds counts for a single phase or the overall response.
+type PhaseSummary struct {
+	Promoted int `json:"promoted"`
+	Skipped  int `json:"skipped"`
+	Total    int `json:"total"`
+}
+
+// PhaseResult groups the summary and individual results for one phase.
+type PhaseResult struct {
+	Summary PhaseSummary    `json:"summary"`
+	Results []PromoteResult `json:"results"`
+}
+
+// PromotePhases holds results for each promotion phase as explicit fields
+// so that both keys always appear in JSON output, even when empty.
+type PromotePhases struct {
+	Plan  PhaseResult `json:"plan"`
+	Doing PhaseResult `json:"doing"`
+}
+
+// PromoteResponse is the top-level JSON output of the promote command.
+type PromoteResponse struct {
+	Summary PhaseSummary  `json:"summary"`
+	Phases  PromotePhases `json:"phases"`
+}

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -10,8 +10,8 @@ import (
 	"github.com/douhashi/gh-project-promoter/internal/github"
 )
 
-// Run executes both promotion phases and returns all results.
-func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, promoter github.ItemPromoter) ([]github.PromoteResult, error) {
+// Run executes both promotion phases and returns a structured response.
+func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, promoter github.ItemPromoter) (*github.PromoteResponse, error) {
 	meta, err := promoter.FetchProjectMeta(ctx, cfg.Owner, cfg.ProjectNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch project meta: %w", err)
@@ -27,7 +27,46 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, pr
 		return nil, fmt.Errorf("doing phase failed: %w", err)
 	}
 
-	return append(planResults, doingResults...), nil
+	planPhaseResult := buildPhaseResult(planResults)
+	doingPhaseResult := buildPhaseResult(doingResults)
+
+	return &github.PromoteResponse{
+		Summary: github.PhaseSummary{
+			Promoted: planPhaseResult.Summary.Promoted + doingPhaseResult.Summary.Promoted,
+			Skipped:  planPhaseResult.Summary.Skipped + doingPhaseResult.Summary.Skipped,
+			Total:    planPhaseResult.Summary.Total + doingPhaseResult.Summary.Total,
+		},
+		Phases: github.PromotePhases{
+			Plan:  planPhaseResult,
+			Doing: doingPhaseResult,
+		},
+	}, nil
+}
+
+// buildPhaseResult creates a PhaseResult from a slice of PromoteResult,
+// ensuring the results slice is never nil.
+func buildPhaseResult(results []github.PromoteResult) github.PhaseResult {
+	if results == nil {
+		results = make([]github.PromoteResult, 0)
+	}
+	promoted := 0
+	skipped := 0
+	for _, r := range results {
+		switch r.Action {
+		case "promoted":
+			promoted++
+		case "skipped":
+			skipped++
+		}
+	}
+	return github.PhaseResult{
+		Summary: github.PhaseSummary{
+			Promoted: promoted,
+			Skipped:  skipped,
+			Total:    len(results),
+		},
+		Results: results,
+	}
 }
 
 func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) ([]github.PromoteResult, error) {

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -70,12 +70,13 @@ func TestPlanPhase_InboxToPlan(t *testing.T) {
 		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Done"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
+	planResults := resp.Phases.Plan.Results
+	promoted := filterByAction(planResults, "promoted")
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -84,6 +85,12 @@ func TestPlanPhase_InboxToPlan(t *testing.T) {
 	}
 	if promoted[0].ToStatus != "Plan" {
 		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "Plan")
+	}
+	if resp.Phases.Plan.Summary.Promoted != 1 {
+		t.Errorf("plan summary promoted = %d, want 1", resp.Phases.Plan.Summary.Promoted)
+	}
+	if resp.Phases.Plan.Summary.Total != 1 {
+		t.Errorf("plan summary total = %d, want 1", resp.Phases.Plan.Summary.Total)
 	}
 }
 
@@ -97,13 +104,14 @@ func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
 		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
-	skipped := filterByAction(results, "skipped")
+	planResults := resp.Phases.Plan.Results
+	promoted := filterByAction(planResults, "promoted")
+	skipped := filterByAction(planResults, "skipped")
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -112,6 +120,15 @@ func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
 	}
 	if skipped[0].Reason != "plan limit reached" {
 		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "plan limit reached")
+	}
+	if resp.Phases.Plan.Summary.Promoted != 1 {
+		t.Errorf("plan summary promoted = %d, want 1", resp.Phases.Plan.Summary.Promoted)
+	}
+	if resp.Phases.Plan.Summary.Skipped != 2 {
+		t.Errorf("plan summary skipped = %d, want 2", resp.Phases.Plan.Summary.Skipped)
+	}
+	if resp.Phases.Plan.Summary.Total != 3 {
+		t.Errorf("plan summary total = %d, want 3", resp.Phases.Plan.Summary.Total)
 	}
 }
 
@@ -122,19 +139,16 @@ func TestPlanPhase_NoInboxItems(t *testing.T) {
 		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Ready"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	planPromoted := 0
-	for _, r := range results {
-		if r.ToStatus == "Plan" {
-			planPromoted++
-		}
+	if resp.Phases.Plan.Summary.Promoted != 0 {
+		t.Errorf("expected 0 plan promotions, got %d", resp.Phases.Plan.Summary.Promoted)
 	}
-	if planPromoted != 0 {
-		t.Errorf("expected 0 plan promotions, got %d", planPromoted)
+	if len(resp.Phases.Plan.Results) != 0 {
+		t.Errorf("expected 0 plan results, got %d", len(resp.Phases.Plan.Results))
 	}
 }
 
@@ -148,14 +162,17 @@ func TestPlanPhase_PlanLimitZeroPromotesAll(t *testing.T) {
 		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
+	promoted := filterByAction(resp.Phases.Plan.Results, "promoted")
 	if len(promoted) != 3 {
 		t.Fatalf("expected 3 promoted, got %d", len(promoted))
+	}
+	if resp.Phases.Plan.Summary.Promoted != 3 {
+		t.Errorf("plan summary promoted = %d, want 3", resp.Phases.Plan.Summary.Promoted)
 	}
 }
 
@@ -166,17 +183,20 @@ func TestDoingPhase_ReadyToDoing(t *testing.T) {
 		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
+	promoted := filterByAction(resp.Phases.Doing.Results, "promoted")
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
 	if promoted[0].ToStatus != "In progress" {
 		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "In progress")
+	}
+	if resp.Phases.Doing.Summary.Promoted != 1 {
+		t.Errorf("doing summary promoted = %d, want 1", resp.Phases.Doing.Summary.Promoted)
 	}
 }
 
@@ -188,13 +208,13 @@ func TestDoingPhase_SameRepoSecondSkipped(t *testing.T) {
 		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
-	skipped := filterByAction(results, "skipped")
+	promoted := filterByAction(resp.Phases.Doing.Results, "promoted")
+	skipped := filterByAction(resp.Phases.Doing.Results, "skipped")
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -203,6 +223,12 @@ func TestDoingPhase_SameRepoSecondSkipped(t *testing.T) {
 	}
 	if skipped[0].Reason != "repository already has doing issue" {
 		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "repository already has doing issue")
+	}
+	if resp.Phases.Doing.Summary.Promoted != 1 {
+		t.Errorf("doing summary promoted = %d, want 1", resp.Phases.Doing.Summary.Promoted)
+	}
+	if resp.Phases.Doing.Summary.Skipped != 1 {
+		t.Errorf("doing summary skipped = %d, want 1", resp.Phases.Doing.Summary.Skipped)
 	}
 }
 
@@ -214,12 +240,12 @@ func TestDoingPhase_ExistingDoingRepoSkipped(t *testing.T) {
 		{ID: "2", Title: "Ready Issue", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	skipped := filterByAction(results, "skipped")
+	skipped := filterByAction(resp.Phases.Doing.Results, "skipped")
 	if len(skipped) != 1 {
 		t.Fatalf("expected 1 skipped, got %d", len(skipped))
 	}
@@ -236,14 +262,17 @@ func TestDoingPhase_DifferentReposBothPromoted(t *testing.T) {
 		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
+	promoted := filterByAction(resp.Phases.Doing.Results, "promoted")
 	if len(promoted) != 2 {
 		t.Fatalf("expected 2 promoted, got %d", len(promoted))
+	}
+	if resp.Phases.Doing.Summary.Promoted != 2 {
+		t.Errorf("doing summary promoted = %d, want 2", resp.Phases.Doing.Summary.Promoted)
 	}
 }
 
@@ -301,19 +330,29 @@ func TestRun_BothPhasesCombined(t *testing.T) {
 		{ID: "4", Title: "Doing 1", URL: "https://github.com/owner/repo-d/issues/1", Status: "In progress"},
 	}
 
-	results, err := Run(context.Background(), cfg, items, mp)
+	resp, err := Run(context.Background(), cfg, items, mp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(results, "promoted")
-	skipped := filterByAction(results, "skipped")
 	// Plan: 1 promoted (limit=1), 1 skipped. Doing: 1 promoted.
-	if len(promoted) != 2 {
-		t.Fatalf("expected 2 promoted, got %d", len(promoted))
+	if resp.Phases.Plan.Summary.Promoted != 1 {
+		t.Errorf("plan promoted = %d, want 1", resp.Phases.Plan.Summary.Promoted)
 	}
-	if len(skipped) != 1 {
-		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	if resp.Phases.Plan.Summary.Skipped != 1 {
+		t.Errorf("plan skipped = %d, want 1", resp.Phases.Plan.Summary.Skipped)
+	}
+	if resp.Phases.Doing.Summary.Promoted != 1 {
+		t.Errorf("doing promoted = %d, want 1", resp.Phases.Doing.Summary.Promoted)
+	}
+	if resp.Summary.Promoted != 2 {
+		t.Errorf("total promoted = %d, want 2", resp.Summary.Promoted)
+	}
+	if resp.Summary.Skipped != 1 {
+		t.Errorf("total skipped = %d, want 1", resp.Summary.Skipped)
+	}
+	if resp.Summary.Total != 3 {
+		t.Errorf("total = %d, want 3", resp.Summary.Total)
 	}
 }
 
@@ -342,6 +381,29 @@ func TestRun_FetchMetaError(t *testing.T) {
 	_, err := Run(context.Background(), cfg, nil, mp)
 	if err == nil {
 		t.Fatal("expected error but got nil")
+	}
+}
+
+func TestRun_EmptyItems_ResultsNotNil(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+
+	resp, err := Run(context.Background(), cfg, []github.ProjectItem{}, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Phases.Plan.Results == nil {
+		t.Error("plan results should not be nil")
+	}
+	if resp.Phases.Doing.Results == nil {
+		t.Error("doing results should not be nil")
+	}
+	if len(resp.Phases.Plan.Results) != 0 {
+		t.Errorf("plan results length = %d, want 0", len(resp.Phases.Plan.Results))
+	}
+	if len(resp.Phases.Doing.Results) != 0 {
+		t.Errorf("doing results length = %d, want 0", len(resp.Phases.Doing.Results))
 	}
 }
 


### PR DESCRIPTION
Closes #25

## 変更内容
- `PromoteResponse`, `PromotePhases`, `PhaseResult`, `PhaseSummary` の新型を `types.go` に追加
- `promote.Run` の戻り値を `*PromoteResponse` に変更し、フェーズ別グルーピング＋サマリを返す
- `cmd/promote.go` の JSON 出力を新フォーマットに対応
- 全テストを新型に対応、サマリ値テスト・空スライス保証テスト追加
- `docs/business/model.md` に出力フォーマットセクション追記

## レビュー結果
内部レビュー通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)