### PR TITLE
Improve README documentation and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+BINARY := ghpp
+MODULE := github.com/douhashi/gh-project-promoter
+GOFLAGS := -trimpath
+LDFLAGS := -s -w
+
+.PHONY: build test lint clean install
+
+build:
+	CGO_ENABLED=0 go build $(GOFLAGS) -ldflags '$(LDFLAGS)' -o $(BINARY) .
+
+test:
+	go test ./...
+
+lint:
+	go vet ./...
+
+clean:
+	rm -f $(BINARY)
+
+install: build
+	mv $(BINARY) $(GOPATH)/bin/$(BINARY)

--- a/README.md
+++ b/README.md
@@ -1,45 +1,107 @@
 # Github Project Promoter (GHPP)
 
 GitHub Projects をベースにした、プロジェクト進行ワークフローを支援する CLI ツール。
+定義済みの昇格ルールに基づいて Issue のステータスを自動的に Promote（昇格）させ、ステータス管理の運用コストを削減します。
 
-## 機能
+## ステータスフロー
 
-- 定義済みの昇格ルールに基づいて Issue のステータスを自動 Promote
-  - **計画フェーズ**: `inbox` → `plan`（上限数付き）
-  - **実行フェーズ**: `ready` → `doing`（リポジトリ単位で1つまで）
-
-## セットアップ
-
-```bash
-# ビルド
-go build -o ghpp .
-
-# 環境変数の設定（.env ファイルまたは直接指定）
-export GH_TOKEN=your_token
-export GHPP_OWNER=your_org
-export GHPP_PROJECT_NUMBER=1
+```
+inbox → plan → ready → doing
 ```
 
-## コマンド
+GHPP は上記フローのうち、以下2つの昇格を自動化します。
 
-| コマンド | 説明 |
-|---|---|
-| `ghpp promote` | 昇格ルールに基づいて Issue のステータスを自動 Promote |
+| フェーズ | 遷移 | 制約 |
+|---|---|---|
+| **計画フェーズ** | `inbox` → `plan` | 一度に昇格する個数に上限あり（デフォルト: 3） |
+| **実行フェーズ** | `ready` → `doing` | リポジトリ単位で1つまで |
+
+## インストール
+
+### リリースバイナリ
+
+[Releases](https://github.com/douhashi/ghpp/releases) から対応プラットフォームのバイナリをダウンロードしてください。
+
+### ソースからビルド
+
+```bash
+go build -o ghpp .
+```
+
+## 使い方
+
+```
+ghpp <command> [flags]
+```
+
+### サブコマンド
+
+#### `promote`
+
+昇格ルールに基づいて Issue のステータスを自動 Promote し、結果を JSON で出力します。
+
+```bash
+# 環境変数で設定済みの場合
+ghpp promote
+
+# フラグで指定
+ghpp promote --token ghp_xxx --owner my-org --project-number 1
+
+# 計画フェーズの上限数を変更
+ghpp promote --plan-limit 5
+
+# ステータス名をカスタマイズ
+ghpp promote --status-inbox "Todo" --status-plan "Planned"
+```
+
+**動作の詳細:**
+
+1. **計画フェーズ** — `inbox` ステータスの Issue を `plan` に昇格。`--plan-limit` で指定された上限数まで昇格します。
+2. **実行フェーズ** — `ready` ステータスの Issue を `doing` に昇格。同一リポジトリで既に `doing` の Issue がある場合はスキップされます。
+
+**出力例:**
+
+```json
+{
+  "summary": { "promoted": 4, "skipped": 2, "total": 6 },
+  "phases": {
+    "plan": {
+      "summary": { "promoted": 3, "skipped": 1, "total": 4 },
+      "results": [
+        {
+          "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Backlog" },
+          "action": "promoted",
+          "to_status": "Plan"
+        }
+      ]
+    },
+    "doing": {
+      "summary": { "promoted": 1, "skipped": 1, "total": 2 },
+      "results": [
+        {
+          "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Ready" },
+          "action": "skipped",
+          "reason": "repository already has an item in doing"
+        }
+      ]
+    }
+  }
+}
+```
+
+- `phases.plan` / `phases.doing` は常にキーが存在（0件でも省略されない）
+- 各 `results` は0件の場合 `[]`（`null` ではない）
+- `action` は `"promoted"` または `"skipped"`
 
 ## 設定
 
-パラメータは **コマンドラインオプション** または **環境変数** で指定できます。
-両方が指定された場合、コマンドラインオプションが優先されます。
+パラメータは **コマンドラインフラグ** または **環境変数** で指定できます。
 
-優先順位: コマンドラインオプション > 環境変数 > デフォルト値
+**優先順位**: コマンドラインフラグ > 環境変数 > デフォルト値
 
-### コマンドラインオプション
+### フラグ一覧
 
-```bash
-ghpp promote --token ghp_xxx --owner my-org --project-number 1 --plan-limit 5
-```
-
-| オプション | 対応する環境変数 | 必須 | デフォルト値 | 説明 |
+| フラグ | 環境変数 | 必須 | デフォルト値 | 説明 |
 |---|---|---|---|---|
 | `--token` | `GH_TOKEN` | Yes | - | GitHub API トークン |
 | `--owner` | `GHPP_OWNER` | Yes | - | GitHub Organization / User 名 |
@@ -50,20 +112,18 @@ ghpp promote --token ghp_xxx --owner my-org --project-number 1 --plan-limit 5
 | `--status-doing` | `GHPP_STATUS_DOING` | No | `In progress` | doing に対応するステータス名 |
 | `--plan-limit` | `GHPP_PLAN_LIMIT` | No | `3` | 計画フェーズの昇格上限数 |
 
-> **セキュリティに関する注意**: `--token` オプションでトークンを渡すと、プロセス一覧やシェル履歴にトークンが残る可能性があります。セキュリティを重視する場合は、環境変数 `GH_TOKEN` または `.env` ファイルでの指定を推奨します。
+> **セキュリティに関する注意**: `--token` でトークンを渡すと、プロセス一覧やシェル履歴にトークンが残る可能性があります。環境変数 `GH_TOKEN` または `.env` ファイルでの指定を推奨します。
 
-### 環境変数
+### 環境変数 / `.env` ファイル
 
-| 変数名 | 必須 | デフォルト値 | 説明 |
-|---|---|---|---|
-| `GH_TOKEN` | Yes | - | GitHub API トークン |
-| `GHPP_OWNER` | Yes | - | GitHub Organization / User 名 |
-| `GHPP_PROJECT_NUMBER` | Yes | - | GitHub Projects の番号 |
-| `GHPP_STATUS_INBOX` | No | `Backlog` | inbox に対応するステータス名 |
-| `GHPP_STATUS_PLAN` | No | `Plan` | plan に対応するステータス名 |
-| `GHPP_STATUS_READY` | No | `Ready` | ready に対応するステータス名 |
-| `GHPP_STATUS_DOING` | No | `In progress` | doing に対応するステータス名 |
-| `GHPP_PLAN_LIMIT` | No | `3` | 計画フェーズの昇格上限数 |
+バイナリと同じディレクトリに `.env` ファイルを配置することで環境変数を設定できます。
+
+```bash
+GH_TOKEN=ghp_xxxxxxxxxxxx
+GHPP_OWNER=my-org
+GHPP_PROJECT_NUMBER=1
+GHPP_PLAN_LIMIT=5
+```
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary
- README を大幅に改善: ステータスフロー図、promote コマンドの出力例、設定セクションの整理
- Makefile を新規追加: build / test / lint / clean / install ターゲット

## Test plan
- [ ] README の表示が GitHub 上で正しくレンダリングされることを確認
- [ ] `make build` / `make test` / `make lint` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)