### PR TITLE
Implement #28: Restructure promote output by action

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,31 +67,34 @@ ghpp promote --status-inbox "Todo" --status-plan "Planned"
   "phases": {
     "plan": {
       "summary": { "promoted": 3, "skipped": 1, "total": 4 },
-      "results": [
-        {
-          "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Backlog" },
-          "action": "promoted",
-          "to_status": "Plan"
-        }
-      ]
+      "results": {
+        "promoted": [
+          {
+            "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Backlog" },
+            "to_status": "Plan"
+          }
+        ],
+        "skipped": []
+      }
     },
     "doing": {
       "summary": { "promoted": 1, "skipped": 1, "total": 2 },
-      "results": [
-        {
-          "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Ready" },
-          "action": "skipped",
-          "reason": "repository already has an item in doing"
-        }
-      ]
+      "results": {
+        "promoted": [],
+        "skipped": [
+          {
+            "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Ready" },
+            "reason": "repository already has doing issue"
+          }
+        ]
+      }
     }
   }
 }
 ```
 
 - `phases.plan` / `phases.doing` は常にキーが存在（0件でも省略されない）
-- 各 `results` は0件の場合 `[]`（`null` ではない）
-- `action` は `"promoted"` または `"skipped"`
+- 各 `results.promoted` / `results.skipped` は0件の場合 `[]`（`null` ではない）
 
 ## 設定
 

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -15,12 +15,22 @@ type ProjectMeta struct {
 	Options   map[string]string // ステータス名 -> Option ID のマップ
 }
 
-// PromoteResult represents the outcome of a single promote attempt.
-type PromoteResult struct {
+// PromotedItem represents a single item that was promoted.
+type PromotedItem struct {
 	Item     ProjectItem `json:"item"`
-	Action   string      `json:"action"` // "promoted" or "skipped"
-	Reason   string      `json:"reason,omitempty"`
-	ToStatus string      `json:"to_status,omitempty"`
+	ToStatus string      `json:"to_status"`
+}
+
+// SkippedItem represents a single item that was skipped.
+type SkippedItem struct {
+	Item   ProjectItem `json:"item"`
+	Reason string      `json:"reason"`
+}
+
+// PhaseResults groups promoted and skipped items for one phase.
+type PhaseResults struct {
+	Promoted []PromotedItem `json:"promoted"`
+	Skipped  []SkippedItem  `json:"skipped"`
 }
 
 // PhaseSummary holds counts for a single phase or the overall response.
@@ -32,8 +42,8 @@ type PhaseSummary struct {
 
 // PhaseResult groups the summary and individual results for one phase.
 type PhaseResult struct {
-	Summary PhaseSummary    `json:"summary"`
-	Results []PromoteResult `json:"results"`
+	Summary PhaseSummary `json:"summary"`
+	Results PhaseResults `json:"results"`
 }
 
 // PromotePhases holds results for each promotion phase as explicit fields

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -43,34 +43,27 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, pr
 	}, nil
 }
 
-// buildPhaseResult creates a PhaseResult from a slice of PromoteResult,
-// ensuring the results slice is never nil.
-func buildPhaseResult(results []github.PromoteResult) github.PhaseResult {
-	if results == nil {
-		results = make([]github.PromoteResult, 0)
+// buildPhaseResult creates a PhaseResult from PhaseResults,
+// ensuring the slices are never nil.
+func buildPhaseResult(results github.PhaseResults) github.PhaseResult {
+	if results.Promoted == nil {
+		results.Promoted = make([]github.PromotedItem, 0)
 	}
-	promoted := 0
-	skipped := 0
-	for _, r := range results {
-		switch r.Action {
-		case "promoted":
-			promoted++
-		case "skipped":
-			skipped++
-		}
+	if results.Skipped == nil {
+		results.Skipped = make([]github.SkippedItem, 0)
 	}
 	return github.PhaseResult{
 		Summary: github.PhaseSummary{
-			Promoted: promoted,
-			Skipped:  skipped,
-			Total:    len(results),
+			Promoted: len(results.Promoted),
+			Skipped:  len(results.Skipped),
+			Total:    len(results.Promoted) + len(results.Skipped),
 		},
 		Results: results,
 	}
 }
 
-func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) ([]github.PromoteResult, error) {
-	var results []github.PromoteResult
+func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) (github.PhaseResults, error) {
+	var results github.PhaseResults
 	promoted := 0
 
 	for _, item := range items {
@@ -79,21 +72,19 @@ func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectIt
 		}
 
 		if cfg.PlanLimit > 0 && promoted >= cfg.PlanLimit {
-			results = append(results, github.PromoteResult{
+			results.Skipped = append(results.Skipped, github.SkippedItem{
 				Item:   item,
-				Action: "skipped",
 				Reason: "plan limit reached",
 			})
 			continue
 		}
 
 		if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusPlan); err != nil {
-			return nil, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusPlan, err)
+			return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusPlan, err)
 		}
 
-		results = append(results, github.PromoteResult{
+		results.Promoted = append(results.Promoted, github.PromotedItem{
 			Item:     item,
-			Action:   "promoted",
 			ToStatus: cfg.StatusPlan,
 		})
 		promoted++
@@ -102,8 +93,8 @@ func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectIt
 	return results, nil
 }
 
-func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) ([]github.PromoteResult, error) {
-	var results []github.PromoteResult
+func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) (github.PhaseResults, error) {
+	var results github.PhaseResults
 
 	// Build set of repos that already have a doing item.
 	doingRepos := make(map[string]bool)
@@ -124,21 +115,19 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 
 		repo := extractRepo(item.URL)
 		if doingRepos[repo] {
-			results = append(results, github.PromoteResult{
+			results.Skipped = append(results.Skipped, github.SkippedItem{
 				Item:   item,
-				Action: "skipped",
 				Reason: "repository already has doing issue",
 			})
 			continue
 		}
 
 		if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusDoing); err != nil {
-			return nil, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusDoing, err)
+			return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusDoing, err)
 		}
 
-		results = append(results, github.PromoteResult{
+		results.Promoted = append(results.Promoted, github.PromotedItem{
 			Item:     item,
-			Action:   "promoted",
 			ToStatus: cfg.StatusDoing,
 		})
 		doingRepos[repo] = true

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -75,8 +75,7 @@ func TestPlanPhase_InboxToPlan(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	planResults := resp.Phases.Plan.Results
-	promoted := filterByAction(planResults, "promoted")
+	promoted := resp.Phases.Plan.Results.Promoted
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -109,9 +108,8 @@ func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	planResults := resp.Phases.Plan.Results
-	promoted := filterByAction(planResults, "promoted")
-	skipped := filterByAction(planResults, "skipped")
+	promoted := resp.Phases.Plan.Results.Promoted
+	skipped := resp.Phases.Plan.Results.Skipped
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -147,8 +145,11 @@ func TestPlanPhase_NoInboxItems(t *testing.T) {
 	if resp.Phases.Plan.Summary.Promoted != 0 {
 		t.Errorf("expected 0 plan promotions, got %d", resp.Phases.Plan.Summary.Promoted)
 	}
-	if len(resp.Phases.Plan.Results) != 0 {
-		t.Errorf("expected 0 plan results, got %d", len(resp.Phases.Plan.Results))
+	if len(resp.Phases.Plan.Results.Promoted) != 0 {
+		t.Errorf("expected 0 plan promoted, got %d", len(resp.Phases.Plan.Results.Promoted))
+	}
+	if len(resp.Phases.Plan.Results.Skipped) != 0 {
+		t.Errorf("expected 0 plan skipped, got %d", len(resp.Phases.Plan.Results.Skipped))
 	}
 }
 
@@ -167,7 +168,7 @@ func TestPlanPhase_PlanLimitZeroPromotesAll(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(resp.Phases.Plan.Results, "promoted")
+	promoted := resp.Phases.Plan.Results.Promoted
 	if len(promoted) != 3 {
 		t.Fatalf("expected 3 promoted, got %d", len(promoted))
 	}
@@ -188,7 +189,7 @@ func TestDoingPhase_ReadyToDoing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(resp.Phases.Doing.Results, "promoted")
+	promoted := resp.Phases.Doing.Results.Promoted
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -213,8 +214,8 @@ func TestDoingPhase_SameRepoSecondSkipped(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(resp.Phases.Doing.Results, "promoted")
-	skipped := filterByAction(resp.Phases.Doing.Results, "skipped")
+	promoted := resp.Phases.Doing.Results.Promoted
+	skipped := resp.Phases.Doing.Results.Skipped
 	if len(promoted) != 1 {
 		t.Fatalf("expected 1 promoted, got %d", len(promoted))
 	}
@@ -245,7 +246,7 @@ func TestDoingPhase_ExistingDoingRepoSkipped(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	skipped := filterByAction(resp.Phases.Doing.Results, "skipped")
+	skipped := resp.Phases.Doing.Results.Skipped
 	if len(skipped) != 1 {
 		t.Fatalf("expected 1 skipped, got %d", len(skipped))
 	}
@@ -267,7 +268,7 @@ func TestDoingPhase_DifferentReposBothPromoted(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	promoted := filterByAction(resp.Phases.Doing.Results, "promoted")
+	promoted := resp.Phases.Doing.Results.Promoted
 	if len(promoted) != 2 {
 		t.Fatalf("expected 2 promoted, got %d", len(promoted))
 	}
@@ -393,26 +394,28 @@ func TestRun_EmptyItems_ResultsNotNil(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if resp.Phases.Plan.Results == nil {
-		t.Error("plan results should not be nil")
+	if resp.Phases.Plan.Results.Promoted == nil {
+		t.Error("plan promoted should not be nil")
 	}
-	if resp.Phases.Doing.Results == nil {
-		t.Error("doing results should not be nil")
+	if resp.Phases.Plan.Results.Skipped == nil {
+		t.Error("plan skipped should not be nil")
 	}
-	if len(resp.Phases.Plan.Results) != 0 {
-		t.Errorf("plan results length = %d, want 0", len(resp.Phases.Plan.Results))
+	if resp.Phases.Doing.Results.Promoted == nil {
+		t.Error("doing promoted should not be nil")
 	}
-	if len(resp.Phases.Doing.Results) != 0 {
-		t.Errorf("doing results length = %d, want 0", len(resp.Phases.Doing.Results))
+	if resp.Phases.Doing.Results.Skipped == nil {
+		t.Error("doing skipped should not be nil")
 	}
-}
-
-func filterByAction(results []github.PromoteResult, action string) []github.PromoteResult {
-	var filtered []github.PromoteResult
-	for _, r := range results {
-		if r.Action == action {
-			filtered = append(filtered, r)
-		}
+	if len(resp.Phases.Plan.Results.Promoted) != 0 {
+		t.Errorf("plan promoted length = %d, want 0", len(resp.Phases.Plan.Results.Promoted))
 	}
-	return filtered
+	if len(resp.Phases.Doing.Results.Promoted) != 0 {
+		t.Errorf("doing promoted length = %d, want 0", len(resp.Phases.Doing.Results.Promoted))
+	}
+	if len(resp.Phases.Plan.Results.Skipped) != 0 {
+		t.Errorf("plan skipped length = %d, want 0", len(resp.Phases.Plan.Results.Skipped))
+	}
+	if len(resp.Phases.Doing.Results.Skipped) != 0 {
+		t.Errorf("doing skipped length = %d, want 0", len(resp.Phases.Doing.Results.Skipped))
+	}
 }


### PR DESCRIPTION
Closes #28

## 変更内容
- `PromoteResult` 型を削除し、`PromotedItem`/`SkippedItem`/`PhaseResults` の3型に分離
- `PhaseResult.Results` をフラット配列からアクション別グルーピング (`promoted`/`skipped`) に変更
- `planPhase`/`doingPhase` の戻り値を `PhaseResults` に変更
- `buildPhaseResult` を `len()` ベースに簡素化
- テストから `filterByAction` ヘルパーを削除し、直接フィールドアクセスに変更
- README の出力例を新構造に更新

## レビュー結果
内部レビュー通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)