### PR TITLE
Implement #30: Add key field to promote output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ ghpp promote --status-inbox "Todo" --status-plan "Planned"
         "promoted": [
           {
             "item": { "id": "...", "title": "Issue title", "url": "https://...", "status": "Backlog" },
+            "key": "plan-douhashi-ghpp-123",
             "to_status": "Plan"
           }
         ],

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -18,6 +18,7 @@ type ProjectMeta struct {
 // PromotedItem represents a single item that was promoted.
 type PromotedItem struct {
 	Item     ProjectItem `json:"item"`
+	Key      string      `json:"key,omitempty"`
 	ToStatus string      `json:"to_status"`
 }
 

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -85,6 +85,7 @@ func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectIt
 
 		results.Promoted = append(results.Promoted, github.PromotedItem{
 			Item:     item,
+			Key:      extractKey(item.URL, "plan"),
 			ToStatus: cfg.StatusPlan,
 		})
 		promoted++
@@ -128,12 +129,26 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 
 		results.Promoted = append(results.Promoted, github.PromotedItem{
 			Item:     item,
+			Key:      extractKey(item.URL, "doing"),
 			ToStatus: cfg.StatusDoing,
 		})
 		doingRepos[repo] = true
 	}
 
 	return results, nil
+}
+
+// extractKey builds a key string "{phase}-{owner}-{repo}-{number}" from a GitHub URL and phase name.
+func extractKey(rawURL string, phase string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 4 {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", phase, parts[0], parts[1], parts[3])
 }
 
 // extractRepo extracts "owner/repo" from a GitHub issue/PR URL.

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -85,6 +85,9 @@ func TestPlanPhase_InboxToPlan(t *testing.T) {
 	if promoted[0].ToStatus != "Plan" {
 		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "Plan")
 	}
+	if promoted[0].Key != "plan-owner-repo-1" {
+		t.Errorf("Key = %q, want %q", promoted[0].Key, "plan-owner-repo-1")
+	}
 	if resp.Phases.Plan.Summary.Promoted != 1 {
 		t.Errorf("plan summary promoted = %d, want 1", resp.Phases.Plan.Summary.Promoted)
 	}
@@ -118,6 +121,9 @@ func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
 	}
 	if skipped[0].Reason != "plan limit reached" {
 		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "plan limit reached")
+	}
+	if promoted[0].Key != "plan-owner-repo-1" {
+		t.Errorf("promoted Key = %q, want %q", promoted[0].Key, "plan-owner-repo-1")
 	}
 	if resp.Phases.Plan.Summary.Promoted != 1 {
 		t.Errorf("plan summary promoted = %d, want 1", resp.Phases.Plan.Summary.Promoted)
@@ -196,6 +202,9 @@ func TestDoingPhase_ReadyToDoing(t *testing.T) {
 	if promoted[0].ToStatus != "In progress" {
 		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "In progress")
 	}
+	if promoted[0].Key != "doing-owner-repo-a-1" {
+		t.Errorf("Key = %q, want %q", promoted[0].Key, "doing-owner-repo-a-1")
+	}
 	if resp.Phases.Doing.Summary.Promoted != 1 {
 		t.Errorf("doing summary promoted = %d, want 1", resp.Phases.Doing.Summary.Promoted)
 	}
@@ -224,6 +233,9 @@ func TestDoingPhase_SameRepoSecondSkipped(t *testing.T) {
 	}
 	if skipped[0].Reason != "repository already has doing issue" {
 		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "repository already has doing issue")
+	}
+	if promoted[0].Key != "doing-owner-repo-a-1" {
+		t.Errorf("promoted Key = %q, want %q", promoted[0].Key, "doing-owner-repo-a-1")
 	}
 	if resp.Phases.Doing.Summary.Promoted != 1 {
 		t.Errorf("doing summary promoted = %d, want 1", resp.Phases.Doing.Summary.Promoted)
@@ -274,6 +286,55 @@ func TestDoingPhase_DifferentReposBothPromoted(t *testing.T) {
 	}
 	if resp.Phases.Doing.Summary.Promoted != 2 {
 		t.Errorf("doing summary promoted = %d, want 2", resp.Phases.Doing.Summary.Promoted)
+	}
+}
+
+func TestExtractKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		url   string
+		phase string
+		want  string
+	}{
+		{
+			name:  "issue URL with plan phase",
+			url:   "https://github.com/owner/repo/issues/123",
+			phase: "plan",
+			want:  "plan-owner-repo-123",
+		},
+		{
+			name:  "pull request URL with doing phase",
+			url:   "https://github.com/org/project/pull/456",
+			phase: "doing",
+			want:  "doing-org-project-456",
+		},
+		{
+			name:  "too short path",
+			url:   "https://github.com/owner/repo",
+			phase: "plan",
+			want:  "",
+		},
+		{
+			name:  "empty URL",
+			url:   "",
+			phase: "plan",
+			want:  "",
+		},
+		{
+			name:  "invalid URL",
+			url:   "not-a-url",
+			phase: "doing",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractKey(tt.url, tt.phase)
+			if got != tt.want {
+				t.Errorf("extractKey(%q, %q) = %q, want %q", tt.url, tt.phase, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #30

## 変更内容

- `PromoteResult` に `Key` フィールド追加（`{phase}-{owner}-{repo}-{number}` 形式）
- `extractKey` 関数を新設し、`planPhase`/`doingPhase` で promoted 時に key を生成
- テーブル駆動テスト `TestExtractKey` を追加、既存テスト4箇所に Key 検証を追加
- README の出力例に `key` フィールドを追加

## レビュー結果

内部レビュー通過済み