### PR TITLE
Implement #32: Add body and labels to promote output item

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -89,12 +89,24 @@ type fieldValueNode struct {
 type itemContent struct {
 	TypeName string `graphql:"__typename"`
 	Issue    struct {
-		Title string
-		URL   string `graphql:"url"`
+		Title  string
+		URL    string `graphql:"url"`
+		Body   string
+		Labels struct {
+			Nodes []struct {
+				Name string
+			}
+		} `graphql:"labels(first: 50)"`
 	} `graphql:"... on Issue"`
 	PullRequest struct {
-		Title string
-		URL   string `graphql:"url"`
+		Title  string
+		URL    string `graphql:"url"`
+		Body   string
+		Labels struct {
+			Nodes []struct {
+				Name string
+			}
+		} `graphql:"labels(first: 50)"`
 	} `graphql:"... on PullRequest"`
 }
 
@@ -293,15 +305,26 @@ func (c *Client) UpdateItemStatus(ctx context.Context, meta *ProjectMeta, itemID
 }
 
 func toProjectItem(node itemNode) ProjectItem {
-	item := ProjectItem{ID: node.ID}
+	item := ProjectItem{
+		ID:     node.ID,
+		Labels: make([]string, 0),
+	}
 
 	switch node.Content.TypeName {
 	case "Issue":
 		item.Title = node.Content.Issue.Title
 		item.URL = node.Content.Issue.URL
+		item.Body = node.Content.Issue.Body
+		for _, l := range node.Content.Issue.Labels.Nodes {
+			item.Labels = append(item.Labels, l.Name)
+		}
 	case "PullRequest":
 		item.Title = node.Content.PullRequest.Title
 		item.URL = node.Content.PullRequest.URL
+		item.Body = node.Content.PullRequest.Body
+		for _, l := range node.Content.PullRequest.Labels.Nodes {
+			item.Labels = append(item.Labels, l.Name)
+		}
 	}
 
 	for _, fv := range node.FieldValues.Nodes {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -52,6 +52,13 @@ func TestFetchProjectItems_User(t *testing.T) {
 									"__typename": "Issue",
 									"title":      "Sample Issue 2",
 									"url":        "https://github.com/douhashi/gh-project-promoter/issues/7",
+									"body":       "Issue 2 body",
+									"labels": map[string]interface{}{
+										"nodes": []interface{}{
+											map[string]interface{}{"name": "bug"},
+											map[string]interface{}{"name": "urgent"},
+										},
+									},
 								},
 							},
 							map[string]interface{}{
@@ -72,6 +79,10 @@ func TestFetchProjectItems_User(t *testing.T) {
 									"__typename": "Issue",
 									"title":      "Sample Issue 1",
 									"url":        "https://github.com/douhashi/gh-project-promoter/issues/6",
+									"body":       "Issue 1 body",
+									"labels": map[string]interface{}{
+										"nodes": []interface{}{},
+									},
 								},
 							},
 						},
@@ -107,9 +118,11 @@ func TestFetchProjectItems_User(t *testing.T) {
 		title  string
 		url    string
 		status string
+		body   string
+		labels []string
 	}{
-		{0, "PVTI_001", "Sample Issue 2", "https://github.com/douhashi/gh-project-promoter/issues/7", "Ready"},
-		{1, "PVTI_002", "Sample Issue 1", "https://github.com/douhashi/gh-project-promoter/issues/6", "Backlog"},
+		{0, "PVTI_001", "Sample Issue 2", "https://github.com/douhashi/gh-project-promoter/issues/7", "Ready", "Issue 2 body", []string{"bug", "urgent"}},
+		{1, "PVTI_002", "Sample Issue 1", "https://github.com/douhashi/gh-project-promoter/issues/6", "Backlog", "Issue 1 body", []string{}},
 	}
 
 	for _, tt := range tests {
@@ -125,6 +138,18 @@ func TestFetchProjectItems_User(t *testing.T) {
 		}
 		if item.Status != tt.status {
 			t.Errorf("items[%d].Status = %q, want %q", tt.idx, item.Status, tt.status)
+		}
+		if item.Body != tt.body {
+			t.Errorf("items[%d].Body = %q, want %q", tt.idx, item.Body, tt.body)
+		}
+		if len(item.Labels) != len(tt.labels) {
+			t.Errorf("items[%d].Labels length = %d, want %d", tt.idx, len(item.Labels), len(tt.labels))
+		} else {
+			for i, l := range item.Labels {
+				if l != tt.labels[i] {
+					t.Errorf("items[%d].Labels[%d] = %q, want %q", tt.idx, i, l, tt.labels[i])
+				}
+			}
 		}
 	}
 }

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -2,10 +2,12 @@ package github
 
 // ProjectItem represents a single item in a GitHub Project.
 type ProjectItem struct {
-	ID     string `json:"id"`
-	Title  string `json:"title"`
-	URL    string `json:"url"`
-	Status string `json:"status"`
+	ID     string   `json:"id"`
+	Title  string   `json:"title"`
+	URL    string   `json:"url"`
+	Status string   `json:"status"`
+	Body   string   `json:"body"`
+	Labels []string `json:"labels"`
 }
 
 // ProjectMeta holds project-level metadata needed for mutations.

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -66,8 +66,8 @@ func TestPlanPhase_InboxToPlan(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
-		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Done"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Done", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -101,9 +101,9 @@ func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PlanLimit = 1
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
-		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog"},
-		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -140,7 +140,7 @@ func TestPlanPhase_NoInboxItems(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Ready"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Ready", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -164,9 +164,9 @@ func TestPlanPhase_PlanLimitZeroPromotesAll(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PlanLimit = 0
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
-		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog"},
-		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+		{ID: "3", Title: "Issue 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -187,7 +187,7 @@ func TestDoingPhase_ReadyToDoing(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -214,8 +214,8 @@ func TestDoingPhase_SameRepoSecondSkipped(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
-		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -249,8 +249,8 @@ func TestDoingPhase_ExistingDoingRepoSkipped(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Doing Issue", URL: "https://github.com/owner/repo-a/issues/1", Status: "In progress"},
-		{ID: "2", Title: "Ready Issue", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready"},
+		{ID: "1", Title: "Doing Issue", URL: "https://github.com/owner/repo-a/issues/1", Status: "In progress", Labels: []string{}},
+		{ID: "2", Title: "Ready Issue", URL: "https://github.com/owner/repo-a/issues/2", Status: "Ready", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -271,8 +271,8 @@ func TestDoingPhase_DifferentReposBothPromoted(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready"},
-		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -386,10 +386,10 @@ func TestRun_BothPhasesCombined(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PlanLimit = 1
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Inbox 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog"},
-		{ID: "2", Title: "Inbox 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Backlog"},
-		{ID: "3", Title: "Ready 1", URL: "https://github.com/owner/repo-c/issues/1", Status: "Ready"},
-		{ID: "4", Title: "Doing 1", URL: "https://github.com/owner/repo-d/issues/1", Status: "In progress"},
+		{ID: "1", Title: "Inbox 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Inbox 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "3", Title: "Ready 1", URL: "https://github.com/owner/repo-c/issues/1", Status: "Ready", Labels: []string{}},
+		{ID: "4", Title: "Doing 1", URL: "https://github.com/owner/repo-d/issues/1", Status: "In progress", Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, mp)
@@ -425,7 +425,7 @@ func TestRun_APIError(t *testing.T) {
 	}
 	cfg := defaultCfg()
 	items := []github.ProjectItem{
-		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog"},
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
 	}
 
 	_, err := Run(context.Background(), cfg, items, mp)


### PR DESCRIPTION
Closes #32

## 変更内容
- `ProjectItem` 構造体に `Body`（Issue説明文）と `Labels`（ラベル名一覧）フィールドを追加
- GraphQLクエリを拡張し、Issue/PullRequest の body と labels を取得
- `toProjectItem()` で body/labels のマッピングを追加（Labels は空スライスで初期化し JSON `null` を回避）
- テストを更新（モックレスポンス・アサーション追加）

## レビュー結果
内部レビュー通過済み