### PR TITLE
Implement #34: Restrict promote target to Issues only

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -98,16 +98,6 @@ type itemContent struct {
 			}
 		} `graphql:"labels(first: 50)"`
 	} `graphql:"... on Issue"`
-	PullRequest struct {
-		Title  string
-		URL    string `graphql:"url"`
-		Body   string
-		Labels struct {
-			Nodes []struct {
-				Name string
-			}
-		} `graphql:"labels(first: 50)"`
-	} `graphql:"... on PullRequest"`
 }
 
 // FetchProjectItems retrieves all items from a GitHub ProjectV2.
@@ -142,6 +132,9 @@ func (c *Client) fetchUserProjectItems(ctx context.Context, owner string, projec
 		}
 
 		for _, node := range q.User.ProjectV2.Items.Nodes {
+			if node.Content.TypeName != "Issue" {
+				continue
+			}
 			allItems = append(allItems, toProjectItem(node))
 		}
 
@@ -171,6 +164,9 @@ func (c *Client) fetchOrgProjectItems(ctx context.Context, owner string, project
 		}
 
 		for _, node := range q.Organization.ProjectV2.Items.Nodes {
+			if node.Content.TypeName != "Issue" {
+				continue
+			}
 			allItems = append(allItems, toProjectItem(node))
 		}
 
@@ -310,19 +306,11 @@ func toProjectItem(node itemNode) ProjectItem {
 		Labels: make([]string, 0),
 	}
 
-	switch node.Content.TypeName {
-	case "Issue":
+	if node.Content.TypeName == "Issue" {
 		item.Title = node.Content.Issue.Title
 		item.URL = node.Content.Issue.URL
 		item.Body = node.Content.Issue.Body
 		for _, l := range node.Content.Issue.Labels.Nodes {
-			item.Labels = append(item.Labels, l.Name)
-		}
-	case "PullRequest":
-		item.Title = node.Content.PullRequest.Title
-		item.URL = node.Content.PullRequest.URL
-		item.Body = node.Content.PullRequest.Body
-		for _, l := range node.Content.PullRequest.Labels.Nodes {
 			item.Labels = append(item.Labels, l.Name)
 		}
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -465,6 +465,107 @@ func TestUpdateItemStatus_InvalidStatus(t *testing.T) {
 	}
 }
 
+func TestFetchProjectItems_IgnoresPullRequests(t *testing.T) {
+	resp := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 2,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": false,
+							"endCursor":   "",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id": "PVTI_ISSUE1",
+								"fieldValues": map[string]interface{}{
+									"nodes": []interface{}{
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldSingleSelectValue",
+											"name":       "Ready",
+											"field": map[string]interface{}{
+												"__typename": "ProjectV2SingleSelectField",
+												"name":       "Status",
+											},
+										},
+									},
+								},
+								"content": map[string]interface{}{
+									"__typename": "Issue",
+									"title":      "Valid Issue",
+									"url":        "https://github.com/example/repo/issues/1",
+									"body":       "Issue body",
+									"labels": map[string]interface{}{
+										"nodes": []interface{}{},
+									},
+								},
+							},
+							map[string]interface{}{
+								"id": "PVTI_PR1",
+								"fieldValues": map[string]interface{}{
+									"nodes": []interface{}{
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldSingleSelectValue",
+											"name":       "In Progress",
+											"field": map[string]interface{}{
+												"__typename": "ProjectV2SingleSelectField",
+												"name":       "Status",
+											},
+										},
+									},
+								},
+								"content": map[string]interface{}{
+									"__typename": "PullRequest",
+									"title":      "Some PR",
+									"url":        "https://github.com/example/repo/pull/2",
+									"body":       "PR body",
+									"labels": map[string]interface{}{
+										"nodes": []interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := newClientWithHTTP(srv.Client())
+	client.inner = newTestGitHubV4Client(srv.URL, srv.Client())
+
+	items, err := client.FetchProjectItems(context.Background(), "testuser", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// PullRequestは結果から除外され、Issueのみが返されることを検証する
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (PullRequest is excluded), got %d", len(items))
+	}
+
+	// Issueのアイテムは正しく取得されていること
+	issueItem := items[0]
+	if issueItem.ID != "PVTI_ISSUE1" {
+		t.Errorf("items[0].ID = %q, want %q", issueItem.ID, "PVTI_ISSUE1")
+	}
+	if issueItem.Title != "Valid Issue" {
+		t.Errorf("items[0].Title = %q, want %q", issueItem.Title, "Valid Issue")
+	}
+	if issueItem.URL != "https://github.com/example/repo/issues/1" {
+		t.Errorf("items[0].URL = %q, want %q", issueItem.URL, "https://github.com/example/repo/issues/1")
+	}
+}
+
 // newTestGitHubV4Client creates a githubv4.Client pointing at a test server.
 func newTestGitHubV4Client(url string, httpClient *http.Client) *githubv4.Client {
 	return githubv4.NewEnterpriseClient(url+"/graphql", httpClient)


### PR DESCRIPTION
Closes #34

## 変更内容

- `internal/github/client.go`:
  - `itemContent` 構造体から `PullRequest` フラグメント（`... on PullRequest`）を削除
  - `toProjectItem()` の `switch` を `if node.Content.TypeName == "Issue"` に変換
  - `fetchUserProjectItems` / `fetchOrgProjectItems` でIssue以外のアイテムをフィルタリングして除外
- `internal/github/client_test.go`:
  - `TestFetchProjectItems_IgnoresPullRequests` テストを追加（IssueとPullRequest混在時にPullRequestが除外されることを検証）

## レビュー結果

内部レビュー通過済み