### PR TITLE
Implement #36: Add demote command

### DIFF
--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -20,10 +20,31 @@
 ├── internal/
 │   ├── config/      # 環境変数・設定の読み込み
 │   ├── github/      # GitHub API クライアント
-│   └── promote/     # 昇格ロジック
+│   ├── promote/     # 昇格ロジック
+│   └── demote/      # 降格ロジック
 ├── docs/            # ドキュメント
 ├── .env.example     # 環境変数のサンプル
 └── go.mod
+```
+
+## コマンド
+
+### promote
+
+滞留 Issue を次のステータスへ昇格させる。
+
+```
+ghpp promote [flags]
+```
+
+### demote
+
+滞留 Issue を前のステータスへ降格させる。`--stale-threshold` で設定した期間（デフォルト: 2h）以上更新がないアイテムが対象。
+
+```
+ghpp demote [flags]
+  --stale-threshold <duration>  降格対象とみなす滞留期間 (env: GHPP_STALE_THRESHOLD, default: 2h)
+  --dry-run                     実際には更新せずに降格対象を表示する
 ```
 
 ## ビルド・実行

--- a/internal/cmd/demote.go
+++ b/internal/cmd/demote.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/demote"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// RunDemote fetches project items via the API, runs the demotion logic, and prints the results as JSON.
+func RunDemote(ctx context.Context, cfg *config.Config, demoter github.ItemPromoter) error {
+	items, err := demoter.FetchProjectItems(ctx, cfg.Owner, cfg.ProjectNumber)
+	if err != nil {
+		return fmt.Errorf("failed to fetch project items: %w", err)
+	}
+
+	resp, err := demote.Run(ctx, cfg, items, demoter)
+	if err != nil {
+		return fmt.Errorf("failed to run demote: %w", err)
+	}
+
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	fmt.Println(string(out))
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 )
 
 const (
-	DefaultStatusInbox = "Backlog"
-	DefaultStatusPlan  = "Plan"
-	DefaultStatusReady = "Ready"
-	DefaultStatusDoing = "In progress"
-	DefaultPlanLimit   = 3
+	DefaultStatusInbox    = "Backlog"
+	DefaultStatusPlan     = "Plan"
+	DefaultStatusReady    = "Ready"
+	DefaultStatusDoing    = "In progress"
+	DefaultPlanLimit      = 3
+	DefaultStaleThreshold = 2 * time.Hour
 )
 
 // getEnvOrDefault returns the value of the environment variable named by the key,
@@ -26,14 +28,16 @@ func getEnvOrDefault(key, defaultValue string) string {
 
 // Config holds application configuration loaded from environment variables.
 type Config struct {
-	Token         string
-	Owner         string
-	ProjectNumber int
-	StatusInbox   string
-	StatusPlan    string
-	StatusReady   string
-	StatusDoing   string
-	PlanLimit     int
+	Token          string
+	Owner          string
+	ProjectNumber  int
+	StatusInbox    string
+	StatusPlan     string
+	StatusReady    string
+	StatusDoing    string
+	PlanLimit      int
+	StaleThreshold time.Duration
+	DryRun         bool
 }
 
 // Load reads environment variables and returns a Config.
@@ -56,6 +60,8 @@ func LoadWithArgs(args []string) (*Config, error) {
 	statusReady := fs.String("status-ready", "", "Status name for ready (env: GHPP_STATUS_READY)")
 	statusDoing := fs.String("status-doing", "", "Status name for doing (env: GHPP_STATUS_DOING)")
 	planLimit := fs.String("plan-limit", "", "Plan promotion limit (env: GHPP_PLAN_LIMIT)")
+	staleThreshold := fs.String("stale-threshold", "", "Stale threshold duration for demote (env: GHPP_STALE_THRESHOLD, default: 2h)")
+	dryRun := fs.Bool("dry-run", false, "Dry-run mode: do not actually update items")
 
 	if args != nil {
 		if err := fs.Parse(args); err != nil {
@@ -115,14 +121,29 @@ func LoadWithArgs(args []string) (*Config, error) {
 		}
 	}
 
+	// Resolve stale threshold
+	resolvedStaleThreshold := DefaultStaleThreshold
+	resolvedStaleThresholdStr := resolve("stale-threshold", *staleThreshold, "GHPP_STALE_THRESHOLD", "")
+	if resolvedStaleThresholdStr != "" {
+		resolvedStaleThreshold, err = time.ParseDuration(resolvedStaleThresholdStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse GHPP_STALE_THRESHOLD: %w", err)
+		}
+	}
+
+	// Resolve dry-run (flag only, no env var)
+	resolvedDryRun := *dryRun
+
 	return &Config{
-		Token:         resolvedToken,
-		Owner:         resolvedOwner,
-		ProjectNumber: resolvedProjectNumber,
-		StatusInbox:   resolvedStatusInbox,
-		StatusPlan:    resolvedStatusPlan,
-		StatusReady:   resolvedStatusReady,
-		StatusDoing:   resolvedStatusDoing,
-		PlanLimit:     resolvedPlanLimit,
+		Token:          resolvedToken,
+		Owner:          resolvedOwner,
+		ProjectNumber:  resolvedProjectNumber,
+		StatusInbox:    resolvedStatusInbox,
+		StatusPlan:     resolvedStatusPlan,
+		StatusReady:    resolvedStatusReady,
+		StatusDoing:    resolvedStatusDoing,
+		PlanLimit:      resolvedPlanLimit,
+		StaleThreshold: resolvedStaleThreshold,
+		DryRun:         resolvedDryRun,
 	}, nil
 }

--- a/internal/demote/demote.go
+++ b/internal/demote/demote.go
@@ -1,0 +1,145 @@
+package demote
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// Run executes both demotion phases and returns a structured response.
+func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, demoter github.ItemPromoter) (*github.DemoteResponse, error) {
+	meta, err := demoter.FetchProjectMeta(ctx, cfg.Owner, cfg.ProjectNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch project meta: %w", err)
+	}
+
+	now := time.Now()
+
+	doingResults, err := doingPhase(ctx, cfg, items, meta, demoter, now)
+	if err != nil {
+		return nil, fmt.Errorf("doing phase failed: %w", err)
+	}
+
+	planResults, err := planPhase(ctx, cfg, items, meta, demoter, now)
+	if err != nil {
+		return nil, fmt.Errorf("plan phase failed: %w", err)
+	}
+
+	doingPhaseResult := buildPhaseResult(doingResults)
+	planPhaseResult := buildPhaseResult(planResults)
+
+	return &github.DemoteResponse{
+		Summary: github.DemoteSummary{
+			Demoted: doingPhaseResult.Summary.Demoted + planPhaseResult.Summary.Demoted,
+			Skipped: doingPhaseResult.Summary.Skipped + planPhaseResult.Summary.Skipped,
+			Total:   doingPhaseResult.Summary.Total + planPhaseResult.Summary.Total,
+		},
+		Phases: github.DemotePhases{
+			Doing: doingPhaseResult,
+			Plan:  planPhaseResult,
+		},
+	}, nil
+}
+
+// buildPhaseResult creates a DemotePhaseResult from DemotePhaseResults,
+// ensuring the slices are never nil.
+func buildPhaseResult(results github.DemotePhaseResults) github.DemotePhaseResult {
+	if results.Demoted == nil {
+		results.Demoted = make([]github.DemotedItem, 0)
+	}
+	if results.Skipped == nil {
+		results.Skipped = make([]github.SkippedItem, 0)
+	}
+	return github.DemotePhaseResult{
+		Summary: github.DemoteSummary{
+			Demoted: len(results.Demoted),
+			Skipped: len(results.Skipped),
+			Total:   len(results.Demoted) + len(results.Skipped),
+		},
+		Results: results,
+	}
+}
+
+func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, demoter github.ItemPromoter, now time.Time) (github.DemotePhaseResults, error) {
+	var results github.DemotePhaseResults
+
+	for _, item := range items {
+		if item.Status != cfg.StatusDoing {
+			continue
+		}
+
+		if now.Sub(item.UpdatedAt) < cfg.StaleThreshold {
+			results.Skipped = append(results.Skipped, github.SkippedItem{
+				Item:   item,
+				Reason: "not stale",
+			})
+			continue
+		}
+
+		if !cfg.DryRun {
+			if err := demoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusReady); err != nil {
+				return results, fmt.Errorf("failed to demote item %s to %s: %w", item.ID, cfg.StatusReady, err)
+			}
+		}
+
+		results.Demoted = append(results.Demoted, github.DemotedItem{
+			Item:       item,
+			Key:        extractKey(item.URL, "doing"),
+			FromStatus: cfg.StatusDoing,
+			ToStatus:   cfg.StatusReady,
+		})
+	}
+
+	return results, nil
+}
+
+func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, demoter github.ItemPromoter, now time.Time) (github.DemotePhaseResults, error) {
+	var results github.DemotePhaseResults
+
+	for _, item := range items {
+		if item.Status != cfg.StatusPlan {
+			continue
+		}
+
+		if now.Sub(item.UpdatedAt) < cfg.StaleThreshold {
+			results.Skipped = append(results.Skipped, github.SkippedItem{
+				Item:   item,
+				Reason: "not stale",
+			})
+			continue
+		}
+
+		if !cfg.DryRun {
+			if err := demoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusInbox); err != nil {
+				return results, fmt.Errorf("failed to demote item %s to %s: %w", item.ID, cfg.StatusInbox, err)
+			}
+		}
+
+		results.Demoted = append(results.Demoted, github.DemotedItem{
+			Item:       item,
+			Key:        extractKey(item.URL, "plan"),
+			FromStatus: cfg.StatusPlan,
+			ToStatus:   cfg.StatusInbox,
+		})
+	}
+
+	return results, nil
+}
+
+// extractKey builds a key string "{phase}-{owner}-{repo}-{number}" from a GitHub URL and phase name.
+func extractKey(rawURL string, phase string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 4 {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", phase, parts[0], parts[1], parts[3])
+}

--- a/internal/demote/demote_test.go
+++ b/internal/demote/demote_test.go
@@ -1,0 +1,320 @@
+package demote
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// mockDemoter implements github.ItemPromoter for testing.
+type mockDemoter struct {
+	meta      *github.ProjectMeta
+	metaErr   error
+	updateErr error
+	updated   []updateCall
+}
+
+type updateCall struct {
+	ItemID     string
+	StatusName string
+}
+
+func (m *mockDemoter) FetchProjectItems(_ context.Context, _ string, _ int) ([]github.ProjectItem, error) {
+	return nil, nil
+}
+
+func (m *mockDemoter) FetchProjectMeta(_ context.Context, _ string, _ int) (*github.ProjectMeta, error) {
+	return m.meta, m.metaErr
+}
+
+func (m *mockDemoter) UpdateItemStatus(_ context.Context, _ *github.ProjectMeta, itemID string, statusName string) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.updated = append(m.updated, updateCall{ItemID: itemID, StatusName: statusName})
+	return nil
+}
+
+var defaultMeta = &github.ProjectMeta{
+	ProjectID: "PVT_001",
+	FieldID:   "PVTSSF_001",
+	Options: map[string]string{
+		"Backlog":     "opt1",
+		"Plan":        "opt2",
+		"Ready":       "opt3",
+		"In progress": "opt4",
+		"Done":        "opt5",
+	},
+}
+
+func defaultCfg() *config.Config {
+	return &config.Config{
+		Owner:          "testowner",
+		ProjectNumber:  1,
+		StatusInbox:    "Backlog",
+		StatusPlan:     "Plan",
+		StatusReady:    "Ready",
+		StatusDoing:    "In progress",
+		StaleThreshold: 2 * time.Hour,
+		DryRun:         false,
+	}
+}
+
+func staleTime() time.Time {
+	return time.Now().Add(-3 * time.Hour) // 3時間前 = stale
+}
+
+func freshTime() time.Time {
+	return time.Now().Add(-1 * time.Hour) // 1時間前 = fresh
+}
+
+// TestDoingPhase_StaleItemDemotedToReady: stale な doing アイテムが ready に降格
+func TestDoingPhase_StaleItemDemotedToReady(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	demoted := resp.Phases.Doing.Results.Demoted
+	if len(demoted) != 1 {
+		t.Fatalf("expected 1 demoted, got %d", len(demoted))
+	}
+	if demoted[0].Item.ID != "1" {
+		t.Errorf("demoted item ID = %q, want %q", demoted[0].Item.ID, "1")
+	}
+	if demoted[0].FromStatus != "In progress" {
+		t.Errorf("FromStatus = %q, want %q", demoted[0].FromStatus, "In progress")
+	}
+	if demoted[0].ToStatus != "Ready" {
+		t.Errorf("ToStatus = %q, want %q", demoted[0].ToStatus, "Ready")
+	}
+	if demoted[0].Key != "doing-owner-repo-1" {
+		t.Errorf("Key = %q, want %q", demoted[0].Key, "doing-owner-repo-1")
+	}
+	if resp.Phases.Doing.Summary.Demoted != 1 {
+		t.Errorf("doing summary demoted = %d, want 1", resp.Phases.Doing.Summary.Demoted)
+	}
+	if len(md.updated) != 1 {
+		t.Fatalf("expected 1 UpdateItemStatus call, got %d", len(md.updated))
+	}
+	if md.updated[0].StatusName != "Ready" {
+		t.Errorf("UpdateItemStatus called with %q, want %q", md.updated[0].StatusName, "Ready")
+	}
+}
+
+// TestDoingPhase_FreshItemSkipped: 新しい doing アイテムはスキップ
+func TestDoingPhase_FreshItemSkipped(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Fresh Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: freshTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	demoted := resp.Phases.Doing.Results.Demoted
+	skipped := resp.Phases.Doing.Results.Skipped
+	if len(demoted) != 0 {
+		t.Fatalf("expected 0 demoted, got %d", len(demoted))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+	if len(md.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(md.updated))
+	}
+}
+
+// TestPlanPhase_StaleItemDemotedToInbox: stale な plan アイテムが inbox に降格
+func TestPlanPhase_StaleItemDemotedToInbox(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "2", Title: "Stale Plan", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", UpdatedAt: staleTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	demoted := resp.Phases.Plan.Results.Demoted
+	if len(demoted) != 1 {
+		t.Fatalf("expected 1 demoted, got %d", len(demoted))
+	}
+	if demoted[0].Item.ID != "2" {
+		t.Errorf("demoted item ID = %q, want %q", demoted[0].Item.ID, "2")
+	}
+	if demoted[0].FromStatus != "Plan" {
+		t.Errorf("FromStatus = %q, want %q", demoted[0].FromStatus, "Plan")
+	}
+	if demoted[0].ToStatus != "Backlog" {
+		t.Errorf("ToStatus = %q, want %q", demoted[0].ToStatus, "Backlog")
+	}
+	if demoted[0].Key != "plan-owner-repo-2" {
+		t.Errorf("Key = %q, want %q", demoted[0].Key, "plan-owner-repo-2")
+	}
+	if resp.Phases.Plan.Summary.Demoted != 1 {
+		t.Errorf("plan summary demoted = %d, want 1", resp.Phases.Plan.Summary.Demoted)
+	}
+}
+
+// TestPlanPhase_FreshItemSkipped: 新しい plan アイテムはスキップ
+func TestPlanPhase_FreshItemSkipped(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "2", Title: "Fresh Plan", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", UpdatedAt: freshTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	demoted := resp.Phases.Plan.Results.Demoted
+	skipped := resp.Phases.Plan.Results.Skipped
+	if len(demoted) != 0 {
+		t.Fatalf("expected 0 demoted, got %d", len(demoted))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+	if len(md.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(md.updated))
+	}
+}
+
+// TestDryRun_UpdateItemStatusNotCalled: dry-run では UpdateItemStatus が呼ばれない
+func TestDryRun_UpdateItemStatusNotCalled(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.DryRun = true
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
+		{ID: "2", Title: "Stale Plan", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", UpdatedAt: staleTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(md.updated) != 0 {
+		t.Errorf("dry-run: expected 0 UpdateItemStatus calls, got %d", len(md.updated))
+	}
+
+	// dry-run でも demoted に記録される
+	if len(resp.Phases.Doing.Results.Demoted) != 1 {
+		t.Errorf("dry-run doing demoted = %d, want 1", len(resp.Phases.Doing.Results.Demoted))
+	}
+	if len(resp.Phases.Plan.Results.Demoted) != 1 {
+		t.Errorf("dry-run plan demoted = %d, want 1", len(resp.Phases.Plan.Results.Demoted))
+	}
+}
+
+// TestRun_SummaryAggregation: 全体サマリの集計が正確
+func TestRun_SummaryAggregation(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo-a/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
+		{ID: "2", Title: "Fresh Doing", URL: "https://github.com/owner/repo-b/issues/2", Status: "In progress", UpdatedAt: freshTime(), Labels: []string{}},
+		{ID: "3", Title: "Stale Plan", URL: "https://github.com/owner/repo-c/issues/3", Status: "Plan", UpdatedAt: staleTime(), Labels: []string{}},
+		{ID: "4", Title: "Fresh Plan", URL: "https://github.com/owner/repo-d/issues/4", Status: "Plan", UpdatedAt: freshTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Phases.Doing.Summary.Demoted != 1 {
+		t.Errorf("doing demoted = %d, want 1", resp.Phases.Doing.Summary.Demoted)
+	}
+	if resp.Phases.Doing.Summary.Skipped != 1 {
+		t.Errorf("doing skipped = %d, want 1", resp.Phases.Doing.Summary.Skipped)
+	}
+	if resp.Phases.Plan.Summary.Demoted != 1 {
+		t.Errorf("plan demoted = %d, want 1", resp.Phases.Plan.Summary.Demoted)
+	}
+	if resp.Phases.Plan.Summary.Skipped != 1 {
+		t.Errorf("plan skipped = %d, want 1", resp.Phases.Plan.Summary.Skipped)
+	}
+	if resp.Summary.Demoted != 2 {
+		t.Errorf("total demoted = %d, want 2", resp.Summary.Demoted)
+	}
+	if resp.Summary.Skipped != 2 {
+		t.Errorf("total skipped = %d, want 2", resp.Summary.Skipped)
+	}
+	if resp.Summary.Total != 4 {
+		t.Errorf("total = %d, want 4", resp.Summary.Total)
+	}
+}
+
+// TestRun_EmptyItems_ResultsNotNil: 空配列でも nil にならない
+func TestRun_EmptyItems_ResultsNotNil(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := defaultCfg()
+
+	resp, err := Run(context.Background(), cfg, []github.ProjectItem{}, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Phases.Doing.Results.Demoted == nil {
+		t.Error("doing demoted should not be nil")
+	}
+	if resp.Phases.Doing.Results.Skipped == nil {
+		t.Error("doing skipped should not be nil")
+	}
+	if resp.Phases.Plan.Results.Demoted == nil {
+		t.Error("plan demoted should not be nil")
+	}
+	if resp.Phases.Plan.Results.Skipped == nil {
+		t.Error("plan skipped should not be nil")
+	}
+}
+
+// TestRun_APIError: エラーハンドリング
+func TestRun_APIError(t *testing.T) {
+	md := &mockDemoter{
+		meta:      defaultMeta,
+		updateErr: errors.New("API error"),
+	}
+	cfg := defaultCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
+	}
+
+	_, err := Run(context.Background(), cfg, items, md)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+// TestRun_FetchMetaError: FetchProjectMeta エラーハンドリング
+func TestRun_FetchMetaError(t *testing.T) {
+	md := &mockDemoter{
+		metaErr: errors.New("meta error"),
+	}
+	cfg := defaultCfg()
+
+	_, err := Run(context.Background(), cfg, nil, md)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -89,10 +89,11 @@ type fieldValueNode struct {
 type itemContent struct {
 	TypeName string `graphql:"__typename"`
 	Issue    struct {
-		Title  string
-		URL    string `graphql:"url"`
-		Body   string
-		Labels struct {
+		Title     string
+		URL       string `graphql:"url"`
+		Body      string
+		UpdatedAt githubv4.DateTime
+		Labels    struct {
 			Nodes []struct {
 				Name string
 			}
@@ -310,6 +311,7 @@ func toProjectItem(node itemNode) ProjectItem {
 		item.Title = node.Content.Issue.Title
 		item.URL = node.Content.Issue.URL
 		item.Body = node.Content.Issue.Body
+		item.UpdatedAt = node.Content.Issue.UpdatedAt.Time
 		for _, l := range node.Content.Issue.Labels.Nodes {
 			item.Labels = append(item.Labels, l.Name)
 		}

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,13 +1,16 @@
 package github
 
+import "time"
+
 // ProjectItem represents a single item in a GitHub Project.
 type ProjectItem struct {
-	ID     string   `json:"id"`
-	Title  string   `json:"title"`
-	URL    string   `json:"url"`
-	Status string   `json:"status"`
-	Body   string   `json:"body"`
-	Labels []string `json:"labels"`
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	URL       string    `json:"url"`
+	Status    string    `json:"status"`
+	Body      string    `json:"body"`
+	Labels    []string  `json:"labels"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // ProjectMeta holds project-level metadata needed for mutations.
@@ -60,4 +63,44 @@ type PromotePhases struct {
 type PromoteResponse struct {
 	Summary PhaseSummary  `json:"summary"`
 	Phases  PromotePhases `json:"phases"`
+}
+
+// DemotedItem represents a single item that was demoted.
+type DemotedItem struct {
+	Item       ProjectItem `json:"item"`
+	Key        string      `json:"key,omitempty"`
+	FromStatus string      `json:"from_status"`
+	ToStatus   string      `json:"to_status"`
+}
+
+// DemotePhaseResults groups demoted and skipped items for one phase.
+type DemotePhaseResults struct {
+	Demoted []DemotedItem `json:"demoted"`
+	Skipped []SkippedItem `json:"skipped"`
+}
+
+// DemoteSummary holds counts for a single demote phase or the overall demote response.
+type DemoteSummary struct {
+	Demoted int `json:"demoted"`
+	Skipped int `json:"skipped"`
+	Total   int `json:"total"`
+}
+
+// DemotePhaseResult groups the summary and individual results for one demote phase.
+type DemotePhaseResult struct {
+	Summary DemoteSummary      `json:"summary"`
+	Results DemotePhaseResults `json:"results"`
+}
+
+// DemotePhases holds results for each demotion phase as explicit fields
+// so that both keys always appear in JSON output, even when empty.
+type DemotePhases struct {
+	Doing DemotePhaseResult `json:"doing"`
+	Plan  DemotePhaseResult `json:"plan"`
+}
+
+// DemoteResponse is the top-level JSON output of the demote command.
+type DemoteResponse struct {
+	Summary DemoteSummary `json:"summary"`
+	Phases  DemotePhases  `json:"phases"`
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("ghpp - GitHub Project Promoter")
 		fmt.Println("Usage: ghpp <command>")
-		fmt.Println("Commands: promote")
+		fmt.Println("Commands: promote, demote")
 		return
 	}
 
@@ -38,6 +38,17 @@ func main() {
 		}
 		client := github.NewClient(cfg.Token)
 		if err := cmd.RunPromote(context.Background(), cfg, client); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	case "demote":
+		cfg, err := config.LoadWithArgs(subArgs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		client := github.NewClient(cfg.Token)
+		if err := cmd.RunDemote(context.Background(), cfg, client); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Closes #36

## 変更内容

- `ghpp demote` コマンドを追加（滞留 Issue を前のステータスへ降格）
- doing → ready / plan → inbox の降格処理を実装
- `--stale-threshold` フラグと `GHPP_STALE_THRESHOLD` 環境変数のサポート（デフォルト: 2h）
- `--dry-run` フラグのサポート
- `promote` と対称的な JSON 出力フォーマット（`DemoteSummary` 型で `demoted` フィールド）
- 全テストケース実装済み・golangci-lint 通過済み

## レビュー結果

内部レビュー通過済み