### PR TITLE
Implement #37: Add --dry-run flag to promote command

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -263,6 +263,28 @@ func TestLoadWithArgs(t *testing.T) {
 				PlanLimit:     DefaultPlanLimit,
 			},
 		},
+		{
+			name: "--dry-run flag",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--dry-run",
+			},
+			env: map[string]string{},
+			want: &Config{
+				Token:          "tok",
+				Owner:          "owner",
+				ProjectNumber:  1,
+				StatusInbox:    DefaultStatusInbox,
+				StatusPlan:     DefaultStatusPlan,
+				StatusReady:    DefaultStatusReady,
+				StatusDoing:    DefaultStatusDoing,
+				PlanLimit:      DefaultPlanLimit,
+				StaleThreshold: DefaultStaleThreshold,
+				DryRun:         true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -313,5 +335,8 @@ func assertConfig(t *testing.T, got, want *Config) {
 	}
 	if got.PlanLimit != want.PlanLimit {
 		t.Errorf("PlanLimit = %d, want %d", got.PlanLimit, want.PlanLimit)
+	}
+	if got.DryRun != want.DryRun {
+		t.Errorf("DryRun = %v, want %v", got.DryRun, want.DryRun)
 	}
 }

--- a/internal/demote/demote.go
+++ b/internal/demote/demote.go
@@ -34,6 +34,7 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, de
 	planPhaseResult := buildPhaseResult(planResults)
 
 	return &github.DemoteResponse{
+		DryRun: cfg.DryRun,
 		Summary: github.DemoteSummary{
 			Demoted: doingPhaseResult.Summary.Demoted + planPhaseResult.Summary.Demoted,
 			Skipped: doingPhaseResult.Summary.Skipped + planPhaseResult.Summary.Skipped,

--- a/internal/demote/demote_test.go
+++ b/internal/demote/demote_test.go
@@ -224,6 +224,11 @@ func TestDryRun_UpdateItemStatusNotCalled(t *testing.T) {
 	if len(resp.Phases.Plan.Results.Demoted) != 1 {
 		t.Errorf("dry-run plan demoted = %d, want 1", len(resp.Phases.Plan.Results.Demoted))
 	}
+
+	// DryRun フィールドが true にセットされている
+	if !resp.DryRun {
+		t.Errorf("DryRun = false, want true")
+	}
 }
 
 // TestRun_SummaryAggregation: 全体サマリの集計が正確

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -61,6 +61,7 @@ type PromotePhases struct {
 
 // PromoteResponse is the top-level JSON output of the promote command.
 type PromoteResponse struct {
+	DryRun  bool          `json:"dry_run"`
 	Summary PhaseSummary  `json:"summary"`
 	Phases  PromotePhases `json:"phases"`
 }
@@ -101,6 +102,7 @@ type DemotePhases struct {
 
 // DemoteResponse is the top-level JSON output of the demote command.
 type DemoteResponse struct {
+	DryRun  bool          `json:"dry_run"`
 	Summary DemoteSummary `json:"summary"`
 	Phases  DemotePhases  `json:"phases"`
 }

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -31,6 +31,7 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, pr
 	doingPhaseResult := buildPhaseResult(doingResults)
 
 	return &github.PromoteResponse{
+		DryRun: cfg.DryRun,
 		Summary: github.PhaseSummary{
 			Promoted: planPhaseResult.Summary.Promoted + doingPhaseResult.Summary.Promoted,
 			Skipped:  planPhaseResult.Summary.Skipped + doingPhaseResult.Summary.Skipped,
@@ -79,8 +80,10 @@ func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectIt
 			continue
 		}
 
-		if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusPlan); err != nil {
-			return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusPlan, err)
+		if !cfg.DryRun {
+			if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusPlan); err != nil {
+				return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusPlan, err)
+			}
 		}
 
 		results.Promoted = append(results.Promoted, github.PromotedItem{
@@ -123,8 +126,10 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 			continue
 		}
 
-		if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusDoing); err != nil {
-			return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusDoing, err)
+		if !cfg.DryRun {
+			if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusDoing); err != nil {
+				return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusDoing, err)
+			}
 		}
 
 		results.Promoted = append(results.Promoted, github.PromotedItem{

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -446,6 +446,68 @@ func TestRun_FetchMetaError(t *testing.T) {
 	}
 }
 
+func TestPlanPhase_DryRun(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.DryRun = true
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// dry-run では UpdateItemStatus が呼ばれない
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+
+	// promoted スライスにはアイテムが含まれる（出力は通常と同じ）
+	promoted := resp.Phases.Plan.Results.Promoted
+	if len(promoted) != 2 {
+		t.Fatalf("expected 2 promoted in output, got %d", len(promoted))
+	}
+
+	// DryRun フィールドが true
+	if !resp.DryRun {
+		t.Error("expected DryRun = true, got false")
+	}
+}
+
+func TestDoingPhase_DryRun(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.DryRun = true
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready", Labels: []string{}},
+		{ID: "2", Title: "Issue 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// dry-run では UpdateItemStatus が呼ばれない
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+
+	// promoted スライスにはアイテムが含まれる（出力は通常と同じ）
+	promoted := resp.Phases.Doing.Results.Promoted
+	if len(promoted) != 2 {
+		t.Fatalf("expected 2 promoted in output, got %d", len(promoted))
+	}
+
+	// DryRun フィールドが true
+	if !resp.DryRun {
+		t.Error("expected DryRun = true, got false")
+	}
+}
+
 func TestRun_EmptyItems_ResultsNotNil(t *testing.T) {
 	mp := &mockPromoter{meta: defaultMeta}
 	cfg := defaultCfg()


### PR DESCRIPTION
Closes #37

## 変更内容

- `promote` コマンドに `--dry-run` フラグを追加
- dry-run 時は `UpdateItemStatus` を呼び出さない（`planPhase`/`doingPhase` の両方でガード）
- 出力フォーマットは通常実行時と同一
- `PromoteResponse` と `DemoteResponse` の両方にトップレベル `"dry_run": true` フィールドを追加
- `config_test.go`・`promote_test.go`・`demote_test.go` にテストを追加

## レビュー結果

内部レビュー通過済み（2ラウンド）