### PR TITLE
Implement #44: Add character limit to extractKey output

### DIFF
--- a/docs/business/model.md
+++ b/docs/business/model.md
@@ -77,3 +77,11 @@ Promote コマンドはフェーズ別サマリ付き JSON を出力する。
 - `phases.plan` / `phases.doing` は常にキーが存在する（0件でも省略されない）
 - 各フェーズの `results` は0件の場合 `[]`（`null` ではない）
 - 各 result の `action` は `"promoted"` または `"skipped"`
+
+### キーフォーマット
+
+各 result の `key` は `{phase}-{owner}-{repository}-{issue_no}` 形式で生成される。
+
+- `owner` は最大5文字、`repository` は最大10文字に切り詰められる
+- `phase` と `issue_no` には切り詰めを適用しない
+- キー全体は概ね最大32文字だが、`phase` と `issue_no` に切り詰めはないため、`issue_no` が大きい場合は超過しうる

--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -7,6 +7,7 @@ import (
 )
 
 // ExtractKey builds a key string "{phase}-{owner}-{repo}-{number}" from a GitHub URL and phase name.
+// Owner is truncated to 5 characters and repository to 10 characters to keep the key within 32 characters.
 func ExtractKey(rawURL string, phase string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -16,7 +17,16 @@ func ExtractKey(rawURL string, phase string) string {
 	if len(parts) < 4 {
 		return ""
 	}
-	return fmt.Sprintf("%s-%s-%s-%s", phase, parts[0], parts[1], parts[3])
+	return fmt.Sprintf("%s-%s-%s-%s", phase, truncate(parts[0], 5), truncate(parts[1], 10), parts[3])
+}
+
+// truncate returns s unchanged if its length is within maxLen,
+// otherwise returns the first maxLen bytes.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
 }
 
 // ExtractRepo extracts "owner/repo" from a GitHub issue/PR URL.

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -43,6 +43,24 @@ func TestExtractKey(t *testing.T) {
 			phase: "doing",
 			want:  "",
 		},
+		{
+			name:  "long owner truncated to 5 chars",
+			url:   "https://github.com/longownername/repo/issues/1",
+			phase: "plan",
+			want:  "plan-longo-repo-1",
+		},
+		{
+			name:  "long repository truncated to 10 chars",
+			url:   "https://github.com/owner/longreponame123/issues/42",
+			phase: "doing",
+			want:  "doing-owner-longrepona-42",
+		},
+		{
+			name:  "both owner and repository truncated",
+			url:   "https://github.com/longownername/verylongreponame/issues/999",
+			phase: "doing",
+			want:  "doing-longo-verylongre-999",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #44

## 変更内容

- `truncate` ヘルパー関数を追加し、`extractKey` 内で owner を最大5文字、repository を最大10文字に切り詰め
- 長い owner/repository 名に対する切り詰めテストケースを3件追加
- `docs/business/model.md` にキーフォーマット仕様（切り詰めルール）を追記

## レビュー結果

内部レビュー通過済み