### PR TITLE
Implement #46: Remove plan phase from demote command

### DIFF
--- a/docs/business/model.md
+++ b/docs/business/model.md
@@ -85,3 +85,46 @@ Promote コマンドはフェーズ別サマリ付き JSON を出力する。
 - `owner` は最大5文字、`repository` は最大10文字に切り詰められる
 - `phase` と `issue_no` には切り詰めを適用しない
 - キー全体は概ね最大32文字だが、`phase` と `issue_no` に切り詰めはないため、`issue_no` が大きい場合は超過しうる
+
+---
+
+## Demote コマンド仕様
+
+demote コマンドは stale（更新から一定時間経過）なアイテムを降格させる。
+
+### 対象フェーズ
+
+| フェーズ | 条件 | 降格先 |
+|--------|------|-------|
+| doing  | `doing` ステータスで stale | `ready` |
+
+> **注意**: `plan` フェーズ（Plan → Backlog）の降格は demote コマンドでは行わない。
+
+### 出力フォーマット
+
+```json
+{
+  "dry_run": false,
+  "summary": {
+    "demoted": 1,
+    "skipped": 1,
+    "total": 2
+  },
+  "phases": {
+    "doing": {
+      "summary": {
+        "demoted": 1,
+        "skipped": 1,
+        "total": 2
+      },
+      "results": {
+        "demoted": [...],
+        "skipped": [...]
+      }
+    }
+  }
+}
+```
+
+- `phases.doing` は常にキーが存在する（0件でも省略されない）
+- `results.demoted` / `results.skipped` は0件の場合 `[]`（`null` ではない）

--- a/internal/cmd/demote_test.go
+++ b/internal/cmd/demote_test.go
@@ -63,7 +63,6 @@ func TestRunDemote(t *testing.T) {
 				Owner:          "testowner",
 				ProjectNumber:  1,
 				StatusInbox:    "Backlog",
-				StatusPlan:     "Plan",
 				StatusReady:    "Ready",
 				StatusDoing:    "In progress",
 				StaleThreshold: time.Hour,

--- a/internal/demote/demote.go
+++ b/internal/demote/demote.go
@@ -10,7 +10,7 @@ import (
 	"github.com/douhashi/gh-project-promoter/internal/urlutil"
 )
 
-// Run executes both demotion phases and returns a structured response.
+// Run executes the demotion phase and returns a structured response.
 func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, demoter github.ItemPromoter) (*github.DemoteResponse, error) {
 	meta, err := demoter.FetchProjectMeta(ctx, cfg.Owner, cfg.ProjectNumber)
 	if err != nil {
@@ -24,24 +24,17 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, de
 		return nil, fmt.Errorf("doing phase failed: %w", err)
 	}
 
-	planResults, err := planPhase(ctx, cfg, items, meta, demoter, now)
-	if err != nil {
-		return nil, fmt.Errorf("plan phase failed: %w", err)
-	}
-
 	doingPhaseResult := buildPhaseResult(doingResults)
-	planPhaseResult := buildPhaseResult(planResults)
 
 	return &github.DemoteResponse{
 		DryRun: cfg.DryRun,
 		Summary: github.DemoteSummary{
-			Demoted: doingPhaseResult.Summary.Demoted + planPhaseResult.Summary.Demoted,
-			Skipped: doingPhaseResult.Summary.Skipped + planPhaseResult.Summary.Skipped,
-			Total:   doingPhaseResult.Summary.Total + planPhaseResult.Summary.Total,
+			Demoted: doingPhaseResult.Summary.Demoted,
+			Skipped: doingPhaseResult.Summary.Skipped,
+			Total:   doingPhaseResult.Summary.Total,
 		},
 		Phases: github.DemotePhases{
 			Doing: doingPhaseResult,
-			Plan:  planPhaseResult,
 		},
 	}, nil
 }
@@ -92,39 +85,6 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 			Key:        urlutil.ExtractKey(item.URL, "doing"),
 			FromStatus: cfg.StatusDoing,
 			ToStatus:   cfg.StatusReady,
-		})
-	}
-
-	return results, nil
-}
-
-func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, demoter github.ItemPromoter, now time.Time) (github.DemotePhaseResults, error) {
-	var results github.DemotePhaseResults
-
-	for _, item := range items {
-		if item.Status != cfg.StatusPlan {
-			continue
-		}
-
-		if now.Sub(item.UpdatedAt) < cfg.StaleThreshold {
-			results.Skipped = append(results.Skipped, github.SkippedItem{
-				Item:   item,
-				Reason: "not stale",
-			})
-			continue
-		}
-
-		if !cfg.DryRun {
-			if err := demoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusInbox); err != nil {
-				return results, fmt.Errorf("failed to demote item %s to %s: %w", item.ID, cfg.StatusInbox, err)
-			}
-		}
-
-		results.Demoted = append(results.Demoted, github.DemotedItem{
-			Item:       item,
-			Key:        urlutil.ExtractKey(item.URL, "plan"),
-			FromStatus: cfg.StatusPlan,
-			ToStatus:   cfg.StatusInbox,
 		})
 	}
 

--- a/internal/demote/demote_test.go
+++ b/internal/demote/demote_test.go
@@ -56,7 +56,6 @@ func defaultCfg() *config.Config {
 		Owner:          "testowner",
 		ProjectNumber:  1,
 		StatusInbox:    "Backlog",
-		StatusPlan:     "Plan",
 		StatusReady:    "Ready",
 		StatusDoing:    "In progress",
 		StaleThreshold: 2 * time.Hour,
@@ -138,66 +137,6 @@ func TestDoingPhase_FreshItemSkipped(t *testing.T) {
 	}
 }
 
-// TestPlanPhase_StaleItemDemotedToInbox: stale な plan アイテムが inbox に降格
-func TestPlanPhase_StaleItemDemotedToInbox(t *testing.T) {
-	md := &mockDemoter{meta: defaultMeta}
-	cfg := defaultCfg()
-	items := []github.ProjectItem{
-		{ID: "2", Title: "Stale Plan", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", UpdatedAt: staleTime(), Labels: []string{}},
-	}
-
-	resp, err := Run(context.Background(), cfg, items, md)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	demoted := resp.Phases.Plan.Results.Demoted
-	if len(demoted) != 1 {
-		t.Fatalf("expected 1 demoted, got %d", len(demoted))
-	}
-	if demoted[0].Item.ID != "2" {
-		t.Errorf("demoted item ID = %q, want %q", demoted[0].Item.ID, "2")
-	}
-	if demoted[0].FromStatus != "Plan" {
-		t.Errorf("FromStatus = %q, want %q", demoted[0].FromStatus, "Plan")
-	}
-	if demoted[0].ToStatus != "Backlog" {
-		t.Errorf("ToStatus = %q, want %q", demoted[0].ToStatus, "Backlog")
-	}
-	if demoted[0].Key != "plan-owner-repo-2" {
-		t.Errorf("Key = %q, want %q", demoted[0].Key, "plan-owner-repo-2")
-	}
-	if resp.Phases.Plan.Summary.Demoted != 1 {
-		t.Errorf("plan summary demoted = %d, want 1", resp.Phases.Plan.Summary.Demoted)
-	}
-}
-
-// TestPlanPhase_FreshItemSkipped: 新しい plan アイテムはスキップ
-func TestPlanPhase_FreshItemSkipped(t *testing.T) {
-	md := &mockDemoter{meta: defaultMeta}
-	cfg := defaultCfg()
-	items := []github.ProjectItem{
-		{ID: "2", Title: "Fresh Plan", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", UpdatedAt: freshTime(), Labels: []string{}},
-	}
-
-	resp, err := Run(context.Background(), cfg, items, md)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	demoted := resp.Phases.Plan.Results.Demoted
-	skipped := resp.Phases.Plan.Results.Skipped
-	if len(demoted) != 0 {
-		t.Fatalf("expected 0 demoted, got %d", len(demoted))
-	}
-	if len(skipped) != 1 {
-		t.Fatalf("expected 1 skipped, got %d", len(skipped))
-	}
-	if len(md.updated) != 0 {
-		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(md.updated))
-	}
-}
-
 // TestDryRun_UpdateItemStatusNotCalled: dry-run では UpdateItemStatus が呼ばれない
 func TestDryRun_UpdateItemStatusNotCalled(t *testing.T) {
 	md := &mockDemoter{meta: defaultMeta}
@@ -205,7 +144,6 @@ func TestDryRun_UpdateItemStatusNotCalled(t *testing.T) {
 	cfg.DryRun = true
 	items := []github.ProjectItem{
 		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
-		{ID: "2", Title: "Stale Plan", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", UpdatedAt: staleTime(), Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, md)
@@ -221,9 +159,6 @@ func TestDryRun_UpdateItemStatusNotCalled(t *testing.T) {
 	if len(resp.Phases.Doing.Results.Demoted) != 1 {
 		t.Errorf("dry-run doing demoted = %d, want 1", len(resp.Phases.Doing.Results.Demoted))
 	}
-	if len(resp.Phases.Plan.Results.Demoted) != 1 {
-		t.Errorf("dry-run plan demoted = %d, want 1", len(resp.Phases.Plan.Results.Demoted))
-	}
 
 	// DryRun フィールドが true にセットされている
 	if !resp.DryRun {
@@ -238,8 +173,6 @@ func TestRun_SummaryAggregation(t *testing.T) {
 	items := []github.ProjectItem{
 		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo-a/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
 		{ID: "2", Title: "Fresh Doing", URL: "https://github.com/owner/repo-b/issues/2", Status: "In progress", UpdatedAt: freshTime(), Labels: []string{}},
-		{ID: "3", Title: "Stale Plan", URL: "https://github.com/owner/repo-c/issues/3", Status: "Plan", UpdatedAt: staleTime(), Labels: []string{}},
-		{ID: "4", Title: "Fresh Plan", URL: "https://github.com/owner/repo-d/issues/4", Status: "Plan", UpdatedAt: freshTime(), Labels: []string{}},
 	}
 
 	resp, err := Run(context.Background(), cfg, items, md)
@@ -253,20 +186,14 @@ func TestRun_SummaryAggregation(t *testing.T) {
 	if resp.Phases.Doing.Summary.Skipped != 1 {
 		t.Errorf("doing skipped = %d, want 1", resp.Phases.Doing.Summary.Skipped)
 	}
-	if resp.Phases.Plan.Summary.Demoted != 1 {
-		t.Errorf("plan demoted = %d, want 1", resp.Phases.Plan.Summary.Demoted)
+	if resp.Summary.Demoted != 1 {
+		t.Errorf("total demoted = %d, want 1", resp.Summary.Demoted)
 	}
-	if resp.Phases.Plan.Summary.Skipped != 1 {
-		t.Errorf("plan skipped = %d, want 1", resp.Phases.Plan.Summary.Skipped)
+	if resp.Summary.Skipped != 1 {
+		t.Errorf("total skipped = %d, want 1", resp.Summary.Skipped)
 	}
-	if resp.Summary.Demoted != 2 {
-		t.Errorf("total demoted = %d, want 2", resp.Summary.Demoted)
-	}
-	if resp.Summary.Skipped != 2 {
-		t.Errorf("total skipped = %d, want 2", resp.Summary.Skipped)
-	}
-	if resp.Summary.Total != 4 {
-		t.Errorf("total = %d, want 4", resp.Summary.Total)
+	if resp.Summary.Total != 2 {
+		t.Errorf("total = %d, want 2", resp.Summary.Total)
 	}
 }
 
@@ -285,12 +212,6 @@ func TestRun_EmptyItems_ResultsNotNil(t *testing.T) {
 	}
 	if resp.Phases.Doing.Results.Skipped == nil {
 		t.Error("doing skipped should not be nil")
-	}
-	if resp.Phases.Plan.Results.Demoted == nil {
-		t.Error("plan demoted should not be nil")
-	}
-	if resp.Phases.Plan.Results.Skipped == nil {
-		t.Error("plan skipped should not be nil")
 	}
 }
 

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -94,10 +94,9 @@ type DemotePhaseResult struct {
 }
 
 // DemotePhases holds results for each demotion phase as explicit fields
-// so that both keys always appear in JSON output, even when empty.
+// so that the key always appears in JSON output, even when empty.
 type DemotePhases struct {
 	Doing DemotePhaseResult `json:"doing"`
-	Plan  DemotePhaseResult `json:"plan"`
 }
 
 // DemoteResponse is the top-level JSON output of the demote command.


### PR DESCRIPTION
Closes #46

## 変更内容

- `internal/github/types.go`: `DemotePhases` 構造体から `Plan` フィールドを削除（JSON 出力の `phases.plan` キーが消える破壊的変更）
- `internal/demote/demote.go`: `planPhase` 関数と関連処理を完全削除、`Run` 関数を `doingPhaseResult` のみに簡略化
- `internal/demote/demote_test.go`: plan フェーズ関連テストを削除・修正、`defaultCfg()` から不要な `StatusPlan` を削除
- `internal/cmd/demote_test.go`: 不要な `StatusPlan` フィールドを削除
- `docs/business/model.md`: demote コマンドの仕様（doing フェーズのみ対象）を追記

## レビュー結果

内部レビュー通過済み