### PR TITLE
Implement #48: Add plan→ready auto-promotion phase with label trigger

### DIFF
--- a/docs/business/model.md
+++ b/docs/business/model.md
@@ -6,7 +6,7 @@
 inbox → plan → ready → doing
 ```
 
-GHPP は上記フローのうち、以下2つの昇格を自動化する。
+GHPP は上記フローのうち、以下3つの昇格を自動化する。
 
 ## 1. 計画フェーズ（inbox → plan）
 
@@ -21,7 +21,31 @@ Issue を `inbox` から `plan` ステータスに昇格させる。
 
 - 一度に昇格する個数に上限を設ける（環境変数 `GHPP_PLAN_LIMIT` で上書き可能）
 
-## 2. 実行フェーズ（ready → doing）
+## 2. 準備フェーズ（plan → ready）
+
+Issue を `plan` から `ready` ステータスに昇格させる。**デフォルト無効**。
+
+### 動作
+
+- `plan` ステータスかつ指定ラベルを保持している Issue を `ready` ステータスに変更する
+- 昇格後もラベルは剥がさない（永続マーカーとして保持）
+- カスケード昇格を許可する（同一 `promote` 実行内で `plan → ready → doing` まで進む Issue があり得る）
+
+### 制約
+
+- **ラベルゲート**: 指定ラベルを持つ Issue のみが対象（ラベル付与自体がゲートとなるため上限なし）
+- ラベルマッチは単一ラベルのみ（複数ラベル指定は扱わない）
+
+### 設定
+
+| フラグ | 環境変数 | デフォルト | 説明 |
+|-------|---------|-----------|------|
+| `--promote-ready-enabled` | `GHPP_PROMOTE_READY_ENABLED` | `false` | 準備フェーズを有効化する |
+| `--planned-label` | `GHPP_PLANNED_LABEL` | `planned` | 昇格トリガーとなるラベル名 |
+
+- `--promote-ready-enabled=true` かつ `--planned-label` が空の場合は設定エラー
+
+## 3. 実行フェーズ（ready → doing）
 
 Issue を `ready` から `doing` ステータスに昇格させる。
 
@@ -61,6 +85,14 @@ Promote コマンドはフェーズ別サマリ付き JSON を出力する。
         }
       ]
     },
+    "ready": {
+      "summary": {
+        "promoted": 1,
+        "skipped": 0,
+        "total": 1
+      },
+      "results": [...]
+    },
     "doing": {
       "summary": {
         "promoted": 1,
@@ -74,7 +106,7 @@ Promote コマンドはフェーズ別サマリ付き JSON を出力する。
 ```
 
 - トップレベルの `summary` は全フェーズの合計値
-- `phases.plan` / `phases.doing` は常にキーが存在する（0件でも省略されない）
+- `phases.plan` / `phases.ready` / `phases.doing` は常にキーが存在する（0件でも省略されない）
 - 各フェーズの `results` は0件の場合 `[]`（`null` ではない）
 - 各 result の `action` は `"promoted"` または `"skipped"`
 

--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -36,6 +36,8 @@
 
 ```
 ghpp promote [flags]
+  --promote-ready-enabled       plan→ready自動昇格を有効化する (env: GHPP_PROMOTE_READY_ENABLED, default: false)
+  --planned-label <label>       plan→ready昇格トリガーとなるラベル名 (env: GHPP_PLANNED_LABEL, default: planned)
 ```
 
 ### demote

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ const (
 	DefaultStatusDoing    = "In progress"
 	DefaultPlanLimit      = 3
 	DefaultStaleThreshold = 2 * time.Hour
+	DefaultPlannedLabel   = "planned"
 )
 
 // getEnvOrDefault returns the value of the environment variable named by the key,
@@ -28,16 +29,18 @@ func getEnvOrDefault(key, defaultValue string) string {
 
 // Config holds application configuration loaded from environment variables.
 type Config struct {
-	Token          string
-	Owner          string
-	ProjectNumber  int
-	StatusInbox    string
-	StatusPlan     string
-	StatusReady    string
-	StatusDoing    string
-	PlanLimit      int
-	StaleThreshold time.Duration
-	DryRun         bool
+	Token               string
+	Owner               string
+	ProjectNumber       int
+	StatusInbox         string
+	StatusPlan          string
+	StatusReady         string
+	StatusDoing         string
+	PlanLimit           int
+	StaleThreshold      time.Duration
+	DryRun              bool
+	PromoteReadyEnabled bool
+	PlannedLabel        string
 }
 
 // Load reads environment variables and returns a Config.
@@ -62,6 +65,8 @@ func LoadWithArgs(args []string) (*Config, error) {
 	planLimit := fs.String("plan-limit", "", "Plan promotion limit (env: GHPP_PLAN_LIMIT)")
 	staleThreshold := fs.String("stale-threshold", "", "Stale threshold duration for demote (env: GHPP_STALE_THRESHOLD, default: 2h)")
 	dryRun := fs.Bool("dry-run", false, "Dry-run mode: do not actually update items")
+	promoteReadyEnabled := fs.Bool("promote-ready-enabled", false, "Enable plan→ready auto-promotion (env: GHPP_PROMOTE_READY_ENABLED, default: false)")
+	plannedLabel := fs.String("planned-label", "", "Label name that triggers plan→ready promotion (env: GHPP_PLANNED_LABEL, default: planned)")
 
 	if args != nil {
 		if err := fs.Parse(args); err != nil {
@@ -134,16 +139,38 @@ func LoadWithArgs(args []string) (*Config, error) {
 	// Resolve dry-run (flag only, no env var)
 	resolvedDryRun := *dryRun
 
+	// Resolve promote-ready-enabled (flag > env > default false)
+	resolvedPromoteReadyEnabled := *promoteReadyEnabled
+	if !flagSet["promote-ready-enabled"] {
+		envVal := os.Getenv("GHPP_PROMOTE_READY_ENABLED")
+		if envVal != "" {
+			resolvedPromoteReadyEnabled, err = strconv.ParseBool(envVal)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse GHPP_PROMOTE_READY_ENABLED: %w", err)
+			}
+		}
+	}
+
+	// Resolve planned-label (flag > env > default "planned")
+	resolvedPlannedLabel := resolve("planned-label", *plannedLabel, "GHPP_PLANNED_LABEL", DefaultPlannedLabel)
+
+	// Validate: promote-ready-enabled=true requires a non-empty planned-label
+	if resolvedPromoteReadyEnabled && resolvedPlannedLabel == "" {
+		return nil, fmt.Errorf("failed to load config: --planned-label (or GHPP_PLANNED_LABEL) must not be empty when --promote-ready-enabled is true")
+	}
+
 	return &Config{
-		Token:          resolvedToken,
-		Owner:          resolvedOwner,
-		ProjectNumber:  resolvedProjectNumber,
-		StatusInbox:    resolvedStatusInbox,
-		StatusPlan:     resolvedStatusPlan,
-		StatusReady:    resolvedStatusReady,
-		StatusDoing:    resolvedStatusDoing,
-		PlanLimit:      resolvedPlanLimit,
-		StaleThreshold: resolvedStaleThreshold,
-		DryRun:         resolvedDryRun,
+		Token:               resolvedToken,
+		Owner:               resolvedOwner,
+		ProjectNumber:       resolvedProjectNumber,
+		StatusInbox:         resolvedStatusInbox,
+		StatusPlan:          resolvedStatusPlan,
+		StatusReady:         resolvedStatusReady,
+		StatusDoing:         resolvedStatusDoing,
+		PlanLimit:           resolvedPlanLimit,
+		StaleThreshold:      resolvedStaleThreshold,
+		DryRun:              resolvedDryRun,
+		PromoteReadyEnabled: resolvedPromoteReadyEnabled,
+		PlannedLabel:        resolvedPlannedLabel,
 	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ var allEnvKeys = []string{
 	"GHPP_STATUS_INBOX", "GHPP_STATUS_PLAN",
 	"GHPP_STATUS_READY", "GHPP_STATUS_DOING",
 	"GHPP_PLAN_LIMIT",
+	"GHPP_PROMOTE_READY_ENABLED", "GHPP_PLANNED_LABEL",
 }
 
 // clearEnv clears all config-related environment variables for test isolation.
@@ -48,6 +49,7 @@ func TestLoad(t *testing.T) {
 				StatusReady:   "Ready",
 				StatusDoing:   "Doing",
 				PlanLimit:     5,
+				PlannedLabel:  DefaultPlannedLabel,
 			},
 		},
 		{
@@ -66,6 +68,7 @@ func TestLoad(t *testing.T) {
 				StatusReady:   "Ready",
 				StatusDoing:   "In progress",
 				PlanLimit:     3,
+				PlannedLabel:  DefaultPlannedLabel,
 			},
 		},
 		{
@@ -162,6 +165,7 @@ func TestLoadWithArgs(t *testing.T) {
 				StatusReady:   "FlagReady",
 				StatusDoing:   "FlagDoing",
 				PlanLimit:     7,
+				PlannedLabel:  DefaultPlannedLabel,
 			},
 		},
 		{
@@ -186,6 +190,7 @@ func TestLoadWithArgs(t *testing.T) {
 				StatusReady:   "EnvReady",
 				StatusDoing:   "EnvDoing",
 				PlanLimit:     4,
+				PlannedLabel:  DefaultPlannedLabel,
 			},
 		},
 		{
@@ -215,6 +220,7 @@ func TestLoadWithArgs(t *testing.T) {
 				StatusReady:   "EnvReady",
 				StatusDoing:   "EnvDoing",
 				PlanLimit:     10,
+				PlannedLabel:  DefaultPlannedLabel,
 			},
 		},
 		{
@@ -261,6 +267,7 @@ func TestLoadWithArgs(t *testing.T) {
 				StatusReady:   DefaultStatusReady,
 				StatusDoing:   DefaultStatusDoing,
 				PlanLimit:     DefaultPlanLimit,
+				PlannedLabel:  DefaultPlannedLabel,
 			},
 		},
 		{
@@ -283,6 +290,7 @@ func TestLoadWithArgs(t *testing.T) {
 				PlanLimit:      DefaultPlanLimit,
 				StaleThreshold: DefaultStaleThreshold,
 				DryRun:         true,
+				PlannedLabel:   DefaultPlannedLabel,
 			},
 		},
 	}
@@ -338,5 +346,190 @@ func assertConfig(t *testing.T, got, want *Config) {
 	}
 	if got.DryRun != want.DryRun {
 		t.Errorf("DryRun = %v, want %v", got.DryRun, want.DryRun)
+	}
+	if got.PromoteReadyEnabled != want.PromoteReadyEnabled {
+		t.Errorf("PromoteReadyEnabled = %v, want %v", got.PromoteReadyEnabled, want.PromoteReadyEnabled)
+	}
+	if got.PlannedLabel != want.PlannedLabel {
+		t.Errorf("PlannedLabel = %q, want %q", got.PlannedLabel, want.PlannedLabel)
+	}
+}
+
+func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		env     map[string]string
+		want    *Config
+		wantErr bool
+	}{
+		{
+			name: "--promote-ready-enabled flag sets field to true",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--promote-ready-enabled",
+				"--planned-label", "planned",
+			},
+			env: map[string]string{},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromoteReadyEnabled: true,
+				PlannedLabel:        "planned",
+			},
+		},
+		{
+			name: "GHPP_PROMOTE_READY_ENABLED env var sets field to true",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{
+				"GHPP_PROMOTE_READY_ENABLED": "true",
+				"GHPP_PLANNED_LABEL":         "my-label",
+			},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromoteReadyEnabled: true,
+				PlannedLabel:        "my-label",
+			},
+		},
+		{
+			name: "flag overrides env var for promote-ready-enabled",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--promote-ready-enabled=false",
+				"--planned-label", "flag-label",
+			},
+			env: map[string]string{
+				"GHPP_PROMOTE_READY_ENABLED": "true",
+				"GHPP_PLANNED_LABEL":         "env-label",
+			},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        "flag-label",
+			},
+		},
+		{
+			name: "default: promote-ready-enabled=false, planned-label=planned",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        DefaultPlannedLabel,
+			},
+		},
+		{
+			name: "promote-ready-enabled=true with empty planned-label flag returns error",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--promote-ready-enabled",
+				"--planned-label", "",
+			},
+			env:     map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "GHPP_PROMOTE_READY_ENABLED invalid value returns error",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{
+				"GHPP_PROMOTE_READY_ENABLED": "notabool",
+			},
+			wantErr: true,
+		},
+		{
+			name: "GHPP_PLANNED_LABEL overrides default",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{
+				"GHPP_PLANNED_LABEL": "custom-label",
+			},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        "custom-label",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			got, err := LoadWithArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertConfig(t, got, tt.want)
+		})
 	}
 }

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -53,9 +53,10 @@ type PhaseResult struct {
 }
 
 // PromotePhases holds results for each promotion phase as explicit fields
-// so that both keys always appear in JSON output, even when empty.
+// so that all keys always appear in JSON output, even when empty.
 type PromotePhases struct {
 	Plan  PhaseResult `json:"plan"`
+	Ready PhaseResult `json:"ready"`
 	Doing PhaseResult `json:"doing"`
 }
 

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -9,7 +9,7 @@ import (
 	"github.com/douhashi/gh-project-promoter/internal/urlutil"
 )
 
-// Run executes both promotion phases and returns a structured response.
+// Run executes all promotion phases and returns a structured response.
 func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, promoter github.ItemPromoter) (*github.PromoteResponse, error) {
 	meta, err := promoter.FetchProjectMeta(ctx, cfg.Owner, cfg.ProjectNumber)
 	if err != nil {
@@ -21,26 +21,59 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, pr
 		return nil, fmt.Errorf("plan phase failed: %w", err)
 	}
 
-	doingResults, err := doingPhase(ctx, cfg, items, meta, promoter)
+	// カスケード昇格: planPhase で昇格したアイテムのステータスをインメモリで更新して次フェーズへ渡す
+	itemsAfterPlan := applyPromotions(items, planResults.Promoted, cfg.StatusPlan)
+
+	readyResults, err := readyPhase(ctx, cfg, itemsAfterPlan, meta, promoter)
+	if err != nil {
+		return nil, fmt.Errorf("ready phase failed: %w", err)
+	}
+
+	// カスケード昇格: readyPhase で昇格したアイテムのステータスをインメモリで更新して次フェーズへ渡す
+	itemsAfterReady := applyPromotions(itemsAfterPlan, readyResults.Promoted, cfg.StatusReady)
+
+	// itemsAfterReady には ready フェーズで昇格済みのアイテムも Ready ステータスとして含まれており、doing フェーズでカスケード昇格される
+	doingResults, err := doingPhase(ctx, cfg, itemsAfterReady, meta, promoter)
 	if err != nil {
 		return nil, fmt.Errorf("doing phase failed: %w", err)
 	}
 
 	planPhaseResult := buildPhaseResult(planResults)
+	readyPhaseResult := buildPhaseResult(readyResults)
 	doingPhaseResult := buildPhaseResult(doingResults)
 
 	return &github.PromoteResponse{
 		DryRun: cfg.DryRun,
 		Summary: github.PhaseSummary{
-			Promoted: planPhaseResult.Summary.Promoted + doingPhaseResult.Summary.Promoted,
-			Skipped:  planPhaseResult.Summary.Skipped + doingPhaseResult.Summary.Skipped,
-			Total:    planPhaseResult.Summary.Total + doingPhaseResult.Summary.Total,
+			Promoted: planPhaseResult.Summary.Promoted + readyPhaseResult.Summary.Promoted + doingPhaseResult.Summary.Promoted,
+			Skipped:  planPhaseResult.Summary.Skipped + readyPhaseResult.Summary.Skipped + doingPhaseResult.Summary.Skipped,
+			Total:    planPhaseResult.Summary.Total + readyPhaseResult.Summary.Total + doingPhaseResult.Summary.Total,
 		},
 		Phases: github.PromotePhases{
 			Plan:  planPhaseResult,
+			Ready: readyPhaseResult,
 			Doing: doingPhaseResult,
 		},
 	}, nil
+}
+
+// applyPromotions returns a new slice of items with the promoted items' statuses updated to newStatus.
+func applyPromotions(items []github.ProjectItem, promoted []github.PromotedItem, newStatus string) []github.ProjectItem {
+	if len(promoted) == 0 {
+		return items
+	}
+	promotedIDs := make(map[string]bool, len(promoted))
+	for _, p := range promoted {
+		promotedIDs[p.Item.ID] = true
+	}
+	result := make([]github.ProjectItem, len(items))
+	for i, item := range items {
+		if promotedIDs[item.ID] {
+			item.Status = newStatus
+		}
+		result[i] = item
+	}
+	return result
 }
 
 // buildPhaseResult creates a PhaseResult from PhaseResults,
@@ -94,6 +127,51 @@ func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectIt
 	}
 
 	return results, nil
+}
+
+func readyPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) (github.PhaseResults, error) {
+	var results github.PhaseResults
+
+	if !cfg.PromoteReadyEnabled {
+		return results, nil
+	}
+
+	for _, item := range items {
+		if item.Status != cfg.StatusPlan {
+			continue
+		}
+		if !hasLabel(item.Labels, cfg.PlannedLabel) {
+			results.Skipped = append(results.Skipped, github.SkippedItem{
+				Item:   item,
+				Reason: "label not matched",
+			})
+			continue
+		}
+
+		if !cfg.DryRun {
+			if err := promoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusReady); err != nil {
+				return results, fmt.Errorf("failed to promote item %s to %s: %w", item.ID, cfg.StatusReady, err)
+			}
+		}
+
+		results.Promoted = append(results.Promoted, github.PromotedItem{
+			Item:     item,
+			Key:      urlutil.ExtractKey(item.URL, "ready"),
+			ToStatus: cfg.StatusReady,
+		})
+	}
+
+	return results, nil
+}
+
+// hasLabel reports whether the label slice contains the target label.
+func hasLabel(labels []string, target string) bool {
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
 }
 
 func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) (github.PhaseResults, error) {

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -449,4 +449,235 @@ func TestRun_EmptyItems_ResultsNotNil(t *testing.T) {
 	if len(resp.Phases.Doing.Results.Skipped) != 0 {
 		t.Errorf("doing skipped length = %d, want 0", len(resp.Phases.Doing.Results.Skipped))
 	}
+	if resp.Phases.Ready.Results.Promoted == nil {
+		t.Error("ready promoted should not be nil")
+	}
+	if resp.Phases.Ready.Results.Skipped == nil {
+		t.Error("ready skipped should not be nil")
+	}
+}
+
+func TestReadyPhase_Disabled(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = false
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Plan Issue", URL: "https://github.com/owner/repo/issues/1", Status: "Plan", Labels: []string{"planned"}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 機能無効時: ready フェーズで昇格しない
+	if len(resp.Phases.Ready.Results.Promoted) != 0 {
+		t.Errorf("expected 0 ready promoted, got %d", len(resp.Phases.Ready.Results.Promoted))
+	}
+	if resp.Phases.Ready.Summary.Promoted != 0 {
+		t.Errorf("ready summary promoted = %d, want 0", resp.Phases.Ready.Summary.Promoted)
+	}
+	// API 呼び出しなし
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+}
+
+func TestReadyPhase_LabelMatch(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = true
+	cfg.PlannedLabel = "planned"
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Plan Issue", URL: "https://github.com/owner/repo/issues/1", Status: "Plan", Labels: []string{"planned"}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Ready.Results.Promoted
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 ready promoted, got %d", len(promoted))
+	}
+	if promoted[0].Item.ID != "1" {
+		t.Errorf("promoted item ID = %q, want %q", promoted[0].Item.ID, "1")
+	}
+	if promoted[0].ToStatus != cfg.StatusReady {
+		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, cfg.StatusReady)
+	}
+	if resp.Phases.Ready.Summary.Promoted != 1 {
+		t.Errorf("ready summary promoted = %d, want 1", resp.Phases.Ready.Summary.Promoted)
+	}
+}
+
+func TestReadyPhase_LabelMismatch(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = true
+	cfg.PlannedLabel = "planned"
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Plan Issue", URL: "https://github.com/owner/repo/issues/1", Status: "Plan", Labels: []string{"other-label"}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Phases.Ready.Results.Promoted) != 0 {
+		t.Errorf("expected 0 ready promoted, got %d", len(resp.Phases.Ready.Results.Promoted))
+	}
+	// ラベルが一致しないアイテムは Skipped に記録される
+	if resp.Phases.Ready.Summary.Promoted != 0 {
+		t.Errorf("ready summary promoted = %d, want 0", resp.Phases.Ready.Summary.Promoted)
+	}
+	if len(resp.Phases.Ready.Results.Skipped) != 1 {
+		t.Errorf("expected 1 ready skipped, got %d", len(resp.Phases.Ready.Results.Skipped))
+	}
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+}
+
+func TestReadyPhase_CustomLabel(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = true
+	cfg.PlannedLabel = "my-custom-label"
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Plan Issue with custom", URL: "https://github.com/owner/repo/issues/1", Status: "Plan", Labels: []string{"my-custom-label"}},
+		{ID: "2", Title: "Plan Issue without", URL: "https://github.com/owner/repo/issues/2", Status: "Plan", Labels: []string{"planned"}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Ready.Results.Promoted
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 ready promoted, got %d", len(promoted))
+	}
+	if promoted[0].Item.ID != "1" {
+		t.Errorf("promoted item ID = %q, want %q", promoted[0].Item.ID, "1")
+	}
+}
+
+func TestReadyPhase_DryRun(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = true
+	cfg.PlannedLabel = "planned"
+	cfg.DryRun = true
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Plan Issue", URL: "https://github.com/owner/repo/issues/1", Status: "Plan", Labels: []string{"planned"}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// dry-run では UpdateItemStatus が呼ばれない
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+
+	// promoted スライスにはアイテムが含まれる
+	promoted := resp.Phases.Ready.Results.Promoted
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 ready promoted in output, got %d", len(promoted))
+	}
+}
+
+func TestCascade_PlanToReadyToDoing(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = true
+	cfg.PlannedLabel = "planned"
+	// plan フェーズ: Backlog -> Plan
+	// ready フェーズ: Plan + "planned" ラベル -> Ready
+	// doing フェーズ: Ready -> In progress
+	items := []github.ProjectItem{
+		{
+			ID:     "1",
+			Title:  "Cascade Issue",
+			URL:    "https://github.com/owner/repo-cascade/issues/1",
+			Status: "Plan",
+			Labels: []string{"planned"},
+		},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ready フェーズで Plan -> Ready に昇格
+	if resp.Phases.Ready.Summary.Promoted != 1 {
+		t.Errorf("ready promoted = %d, want 1", resp.Phases.Ready.Summary.Promoted)
+	}
+
+	// doing フェーズで Ready -> In progress に昇格（カスケード）
+	if resp.Phases.Doing.Summary.Promoted != 1 {
+		t.Errorf("doing promoted = %d, want 1", resp.Phases.Doing.Summary.Promoted)
+	}
+
+	// summary の合算に ready フェーズが含まれる
+	if resp.Summary.Promoted != 2 {
+		t.Errorf("total promoted = %d, want 2", resp.Summary.Promoted)
+	}
+}
+
+func TestRun_ReadyPhaseInSummary(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = true
+	cfg.PlannedLabel = "planned"
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Plan Issue 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Plan", Labels: []string{"planned"}},
+		{ID: "2", Title: "Plan Issue 2", URL: "https://github.com/owner/repo-b/issues/2", Status: "Plan", Labels: []string{"planned"}},
+		{ID: "3", Title: "Inbox Issue", URL: "https://github.com/owner/repo-c/issues/3", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// plan: 1 (Backlog→Plan), ready: 2 (Plan→Ready), doing: 2 (Ready→Doing, cascade)
+	if resp.Phases.Plan.Summary.Promoted != 1 {
+		t.Errorf("plan promoted = %d, want 1", resp.Phases.Plan.Summary.Promoted)
+	}
+	if resp.Phases.Ready.Summary.Promoted != 2 {
+		t.Errorf("ready promoted = %d, want 2", resp.Phases.Ready.Summary.Promoted)
+	}
+	if resp.Phases.Doing.Summary.Promoted != 2 {
+		t.Errorf("doing promoted = %d, want 2", resp.Phases.Doing.Summary.Promoted)
+	}
+	// summary には全フェーズ合算
+	if resp.Summary.Promoted != resp.Phases.Plan.Summary.Promoted+resp.Phases.Ready.Summary.Promoted+resp.Phases.Doing.Summary.Promoted {
+		t.Errorf("summary promoted mismatch: got %d", resp.Summary.Promoted)
+	}
+}
+
+func TestRun_ReadyFieldAlwaysPresent(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PromoteReadyEnabled = false // 機能無効
+
+	resp, err := Run(context.Background(), cfg, []github.ProjectItem{}, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 機能無効時も phases.ready が存在すること（nil でないこと）
+	if resp.Phases.Ready.Results.Promoted == nil {
+		t.Error("phases.ready.results.promoted should not be nil even when disabled")
+	}
+	if resp.Phases.Ready.Results.Skipped == nil {
+		t.Error("phases.ready.results.skipped should not be nil even when disabled")
+	}
 }


### PR DESCRIPTION
Closes #48

## 変更内容

- `--promote-ready-enabled` / `GHPP_PROMOTE_READY_ENABLED` フラグを追加（bool, デフォルト `false`）
- `--planned-label` / `GHPP_PLANNED_LABEL` フラグを追加（string, デフォルト `planned`）
- `promote` コマンドに `readyPhase` を追加（`plan` → `doing` フェーズの間）
- カスケード昇格（`plan → ready → doing`）をインメモリ状態パッチで実現
- `PromotePhases` 構造体に `Ready PhaseResult` フィールドを追加
- `Summary` に `ready` フェーズの件数を合算
- ラベルミスマッチアイテムを `Skipped` に記録
- `--promote-ready-enabled=true` かつ `--planned-label` が空の場合はバリデーションエラー
- テスト8ケース追加、ドキュメント更新

## レビュー結果

内部レビュー通過済み（2回のレビューサイクル完了）