### PR TITLE
Implement #50: Change Plan Limit to WIP cap semantics

### DIFF
--- a/docs/business/model.md
+++ b/docs/business/model.md
@@ -19,7 +19,10 @@ Issue を `inbox` から `plan` ステータスに昇格させる。
 
 ### 制約
 
-- 一度に昇格する個数に上限を設ける（環境変数 `GHPP_PLAN_LIMIT` で上書き可能）
+- Plan カラムの WIP 上限（環境変数 `GHPP_PLAN_LIMIT` で上書き可能、デフォルト3）
+- Plan 状態の Issue 数が PlanLimit 以上の場合、Backlog からの昇格は行わない
+- Plan 状態が PlanLimit 未満の場合は `PlanLimit - 現在の Plan 数` の件数だけ昇格する（空き枠を埋める）
+- Ready / Doing の Issue 数はカウント対象外
 
 ## 2. 準備フェーズ（plan → ready）
 

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -97,6 +97,15 @@ func buildPhaseResult(results github.PhaseResults) github.PhaseResult {
 
 func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) (github.PhaseResults, error) {
 	var results github.PhaseResults
+
+	// Plan カラムの現在の件数をカウントする（WIP 上限の基準）
+	currentPlanCount := 0
+	for _, item := range items {
+		if item.Status == cfg.StatusPlan {
+			currentPlanCount++
+		}
+	}
+
 	promoted := 0
 
 	for _, item := range items {
@@ -104,10 +113,10 @@ func planPhase(ctx context.Context, cfg *config.Config, items []github.ProjectIt
 			continue
 		}
 
-		if cfg.PlanLimit > 0 && promoted >= cfg.PlanLimit {
+		if cfg.PlanLimit > 0 && (currentPlanCount+promoted) >= cfg.PlanLimit {
 			results.Skipped = append(results.Skipped, github.SkippedItem{
 				Item:   item,
-				Reason: "plan limit reached",
+				Reason: fmt.Sprintf("plan limit reached (currently %d/%d in Plan)", currentPlanCount, cfg.PlanLimit),
 			})
 			continue
 		}

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -3,6 +3,7 @@ package promote
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/douhashi/gh-project-promoter/internal/config"
@@ -119,8 +120,8 @@ func TestPlanPhase_PlanLimitExceeded(t *testing.T) {
 	if len(skipped) != 2 {
 		t.Fatalf("expected 2 skipped, got %d", len(skipped))
 	}
-	if skipped[0].Reason != "plan limit reached" {
-		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "plan limit reached")
+	if skipped[0].Reason != "plan limit reached (currently 0/1 in Plan)" {
+		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "plan limit reached (currently 0/1 in Plan)")
 	}
 	if promoted[0].Key != "plan-owner-repo-1" {
 		t.Errorf("promoted Key = %q, want %q", promoted[0].Key, "plan-owner-repo-1")
@@ -180,6 +181,132 @@ func TestPlanPhase_PlanLimitZeroPromotesAll(t *testing.T) {
 	}
 	if resp.Phases.Plan.Summary.Promoted != 3 {
 		t.Errorf("plan summary promoted = %d, want 3", resp.Phases.Plan.Summary.Promoted)
+	}
+}
+
+func TestPlanPhase_ExistingPlanCountReducesAvailable(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PlanLimit = 3
+	// 既存 Plan=2、Backlog=3 → available=1 なので 1件昇格、2件スキップ
+	items := []github.ProjectItem{
+		{ID: "p1", Title: "Plan 1", URL: "https://github.com/owner/repo/issues/10", Status: "Plan", Labels: []string{}},
+		{ID: "p2", Title: "Plan 2", URL: "https://github.com/owner/repo/issues/11", Status: "Plan", Labels: []string{}},
+		{ID: "b1", Title: "Backlog 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "b2", Title: "Backlog 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+		{ID: "b3", Title: "Backlog 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Plan.Results.Promoted
+	skipped := resp.Phases.Plan.Results.Skipped
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d", len(skipped))
+	}
+	wantReason := "plan limit reached (currently 2/3 in Plan)"
+	if skipped[0].Reason != wantReason {
+		t.Errorf("Reason = %q, want %q", skipped[0].Reason, wantReason)
+	}
+}
+
+func TestPlanPhase_ExistingPlanAtLimit(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PlanLimit = 3
+	// 既存 Plan=3、Backlog=2 → available=0 なので 0件昇格、2件スキップ
+	items := []github.ProjectItem{
+		{ID: "p1", Title: "Plan 1", URL: "https://github.com/owner/repo/issues/10", Status: "Plan", Labels: []string{}},
+		{ID: "p2", Title: "Plan 2", URL: "https://github.com/owner/repo/issues/11", Status: "Plan", Labels: []string{}},
+		{ID: "p3", Title: "Plan 3", URL: "https://github.com/owner/repo/issues/12", Status: "Plan", Labels: []string{}},
+		{ID: "b1", Title: "Backlog 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "b2", Title: "Backlog 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Plan.Results.Promoted
+	skipped := resp.Phases.Plan.Results.Skipped
+	if len(promoted) != 0 {
+		t.Fatalf("expected 0 promoted, got %d", len(promoted))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d", len(skipped))
+	}
+	wantReason := "plan limit reached (currently 3/3 in Plan)"
+	if skipped[0].Reason != wantReason {
+		t.Errorf("Reason = %q, want %q", skipped[0].Reason, wantReason)
+	}
+}
+
+func TestPlanPhase_ReadyDoingNotCounted(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.PlanLimit = 2
+	// Plan=0、Ready=2、Doing=2、Backlog=3 → Ready/Doing はカウント外、2件昇格
+	items := []github.ProjectItem{
+		{ID: "r1", Title: "Ready 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Ready", Labels: []string{}},
+		{ID: "r2", Title: "Ready 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready", Labels: []string{}},
+		{ID: "d1", Title: "Doing 1", URL: "https://github.com/owner/repo-c/issues/1", Status: "In progress", Labels: []string{}},
+		{ID: "d2", Title: "Doing 2", URL: "https://github.com/owner/repo-d/issues/1", Status: "In progress", Labels: []string{}},
+		{ID: "b1", Title: "Backlog 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "b2", Title: "Backlog 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+		{ID: "b3", Title: "Backlog 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Plan.Results.Promoted
+	if len(promoted) != 2 {
+		t.Fatalf("expected 2 promoted, got %d", len(promoted))
+	}
+	if resp.Phases.Plan.Summary.Promoted != 2 {
+		t.Errorf("plan summary promoted = %d, want 2", resp.Phases.Plan.Summary.Promoted)
+	}
+}
+
+func TestPlanPhase_DryRun_SkipReasonContainsPlanCount(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := defaultCfg()
+	cfg.DryRun = true
+	cfg.PlanLimit = 2
+	// 既存 Plan=1、Backlog=3 → 1件昇格（dry-run）、2件スキップ
+	items := []github.ProjectItem{
+		{ID: "p1", Title: "Plan 1", URL: "https://github.com/owner/repo/issues/10", Status: "Plan", Labels: []string{}},
+		{ID: "b1", Title: "Backlog 1", URL: "https://github.com/owner/repo/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "b2", Title: "Backlog 2", URL: "https://github.com/owner/repo/issues/2", Status: "Backlog", Labels: []string{}},
+		{ID: "b3", Title: "Backlog 3", URL: "https://github.com/owner/repo/issues/3", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// dry-run では UpdateItemStatus が呼ばれない
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+
+	skipped := resp.Phases.Plan.Results.Skipped
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d", len(skipped))
+	}
+	// スキップ Reason に "1/2" が含まれること
+	if !strings.Contains(skipped[0].Reason, "1/2") {
+		t.Errorf("Reason = %q, want it to contain %q", skipped[0].Reason, "1/2")
 	}
 }
 


### PR DESCRIPTION
Closes #50

## 変更内容

- `internal/promote/promote.go`: `planPhase` 関数の Plan Limit セマンティクスを「1回の実行で Backlog から昇格する件数の上限」から「Plan カラムの WIP 上限」に変更。ループ前に `currentPlanCount`（既存の Plan 状態 Issue 数）を算出し、`(currentPlanCount+promoted) >= cfg.PlanLimit` で WIP 上限チェックを行う。スキップ Reason を `"plan limit reached (currently N/L in Plan)"` 形式に変更。
- `internal/promote/promote_test.go`: 既存テストの Reason 文字列を更新し、新セマンティクス専用テストケース4件を追加（既存Plan考慮、上限到達、Ready/Doing 除外、DryRun Reason）。
- `docs/business/model.md`: Plan Limit の説明を新 WIP 上限セマンティクスに更新。

## レビュー結果

内部レビュー通過済み