### PR TITLE
Implement #51: Change stale judgment source to Status field updatedAt

### DIFF
--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -42,7 +42,7 @@ ghpp promote [flags]
 
 ### demote
 
-滞留 Issue を前のステータスへ降格させる。`--stale-threshold` で設定した期間（デフォルト: 2h）以上更新がないアイテムが対象。
+滞留 Issue を前のステータスへ降格させる。`--stale-threshold` で設定した期間（デフォルト: 2h）以上 Status 遷移が行われていないアイテムが対象。stale 判定は Issue 本体の更新日時ではなく、Status フィールド（`ProjectV2ItemFieldSingleSelectValue`）の `updatedAt` を基準とする。
 
 ```
 ghpp demote [flags]

--- a/internal/demote/demote_test.go
+++ b/internal/demote/demote_test.go
@@ -63,12 +63,14 @@ func defaultCfg() *config.Config {
 	}
 }
 
+// staleTime は Status 遷移から stale 閾値（2h）を超えた時刻を返す。
 func staleTime() time.Time {
-	return time.Now().Add(-3 * time.Hour) // 3時間前 = stale
+	return time.Now().Add(-3 * time.Hour) // Status 遷移から3時間経過 = stale
 }
 
+// freshTime は Status 遷移から stale 閾値（2h）以内の時刻を返す。
 func freshTime() time.Time {
-	return time.Now().Add(-1 * time.Hour) // 1時間前 = fresh
+	return time.Now().Add(-1 * time.Hour) // Status 遷移から1時間経過 = fresh
 }
 
 // TestDoingPhase_StaleItemDemotedToReady: stale な doing アイテムが ready に降格

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -76,8 +76,9 @@ type itemNode struct {
 type fieldValueNode struct {
 	TypeName           string `graphql:"__typename"`
 	ProjectV2ItemField struct {
-		Name  string
-		Field struct {
+		Name      string
+		UpdatedAt githubv4.DateTime
+		Field     struct {
 			TypeName              string `graphql:"__typename"`
 			ProjectV2SingleSelect struct {
 				Name string
@@ -89,11 +90,10 @@ type fieldValueNode struct {
 type itemContent struct {
 	TypeName string `graphql:"__typename"`
 	Issue    struct {
-		Title     string
-		URL       string `graphql:"url"`
-		Body      string
-		UpdatedAt githubv4.DateTime
-		Labels    struct {
+		Title  string
+		URL    string `graphql:"url"`
+		Body   string
+		Labels struct {
 			Nodes []struct {
 				Name string
 			}
@@ -311,7 +311,6 @@ func toProjectItem(node itemNode) ProjectItem {
 		item.Title = node.Content.Issue.Title
 		item.URL = node.Content.Issue.URL
 		item.Body = node.Content.Issue.Body
-		item.UpdatedAt = node.Content.Issue.UpdatedAt.Time
 		for _, l := range node.Content.Issue.Labels.Nodes {
 			item.Labels = append(item.Labels, l.Name)
 		}
@@ -321,6 +320,7 @@ func toProjectItem(node itemNode) ProjectItem {
 		if fv.TypeName == "ProjectV2ItemFieldSingleSelectValue" &&
 			fv.ProjectV2ItemField.Field.ProjectV2SingleSelect.Name == "Status" {
 			item.Status = fv.ProjectV2ItemField.Name
+			item.UpdatedAt = fv.ProjectV2ItemField.UpdatedAt.Time
 			break
 		}
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -566,6 +566,142 @@ func TestFetchProjectItems_IgnoresPullRequests(t *testing.T) {
 	}
 }
 
+// TestFetchProjectItems_UpdatedAt_FromStatusField: Status フィールドの updatedAt が ProjectItem.UpdatedAt に反映される
+func TestFetchProjectItems_UpdatedAt_FromStatusField(t *testing.T) {
+	resp := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 1,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": false,
+							"endCursor":   "",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id": "PVTI_UA1",
+								"fieldValues": map[string]interface{}{
+									"nodes": []interface{}{
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldSingleSelectValue",
+											"name":       "In progress",
+											"updatedAt":  "2024-01-15T10:00:00Z",
+											"field": map[string]interface{}{
+												"__typename": "ProjectV2SingleSelectField",
+												"name":       "Status",
+											},
+										},
+									},
+								},
+								"content": map[string]interface{}{
+									"__typename": "Issue",
+									"title":      "Status UpdatedAt Issue",
+									"url":        "https://github.com/example/repo/issues/10",
+									"body":       "body",
+									"labels": map[string]interface{}{
+										"nodes": []interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	items, err := client.FetchProjectItems(context.Background(), "testuser", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+
+	// Status フィールドの updatedAt (2024-01-15T10:00:00Z) が ProjectItem.UpdatedAt に設定されていること
+	wantTime := "2024-01-15 10:00:00 +0000 UTC"
+	gotTime := items[0].UpdatedAt.UTC().String()
+	if gotTime != wantTime {
+		t.Errorf("UpdatedAt = %q, want %q", gotTime, wantTime)
+	}
+}
+
+// TestFetchProjectItems_UpdatedAt_NoStatusField: Status フィールドがない場合は UpdatedAt がゼロ値になる
+func TestFetchProjectItems_UpdatedAt_NoStatusField(t *testing.T) {
+	resp := graphqlResponse{
+		Data: map[string]interface{}{
+			"user": map[string]interface{}{
+				"projectV2": map[string]interface{}{
+					"items": map[string]interface{}{
+						"totalCount": 1,
+						"pageInfo": map[string]interface{}{
+							"hasNextPage": false,
+							"endCursor":   "",
+						},
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"id": "PVTI_UA2",
+								"fieldValues": map[string]interface{}{
+									"nodes": []interface{}{
+										map[string]interface{}{
+											"__typename": "ProjectV2ItemFieldTextValue",
+										},
+									},
+								},
+								"content": map[string]interface{}{
+									"__typename": "Issue",
+									"title":      "No Status Field Issue",
+									"url":        "https://github.com/example/repo/issues/11",
+									"body":       "body",
+									"labels": map[string]interface{}{
+										"nodes": []interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{inner: newTestGitHubV4Client(srv.URL, srv.Client())}
+
+	items, err := client.FetchProjectItems(context.Background(), "testuser", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+
+	// Status フィールドがない場合は UpdatedAt がゼロ値であること
+	if !items[0].UpdatedAt.IsZero() {
+		t.Errorf("UpdatedAt = %v, want zero value", items[0].UpdatedAt)
+	}
+}
+
 // newTestGitHubV4Client creates a githubv4.Client pointing at a test server.
 func newTestGitHubV4Client(url string, httpClient *http.Client) *githubv4.Client {
 	return githubv4.NewEnterpriseClient(url+"/graphql", httpClient)

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -10,7 +10,7 @@ type ProjectItem struct {
 	Status    string    `json:"status"`
 	Body      string    `json:"body"`
 	Labels    []string  `json:"labels"`
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt time.Time `json:"updated_at"` // Status フィールドの最終更新時刻（ProjectV2ItemFieldSingleSelectValue.updatedAt）
 }
 
 // ProjectMeta holds project-level metadata needed for mutations.


### PR DESCRIPTION
Closes #51

## 変更内容

- `internal/github/client.go`: `fieldValueNode.ProjectV2ItemField` に `UpdatedAt githubv4.DateTime` を追加し、`toProjectItem` 関数で `item.UpdatedAt` の代入元を Issue 本体から Status フィールドの `updatedAt` に切り替え。`itemContent.Issue` から不要な `UpdatedAt` を削除
- `internal/github/types.go`: `ProjectItem.UpdatedAt` に Status フィールドの最終更新時刻であることを示すコメントを追加
- `internal/github/client_test.go`: Status フィールドあり/なし両ケースのテストを追加
- `internal/demote/demote_test.go`: コメントを「Status 遷移からの経過時間」semantics に合わせて更新
- `docs/development/guideline.md`: demote コマンドの stale 判定基準の説明を更新

## レビュー結果

内部レビュー通過済み（全テスト・静的解析パス）