### PR TITLE
Implement #54: Add `ghpp project init` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,87 @@ ghpp promote --status-inbox "Todo" --status-plan "Planned"
 - `phases.plan` / `phases.doing` は常にキーが存在（0件でも省略されない）
 - 各 `results.promoted` / `results.skipped` は0件の場合 `[]`（`null` ではない）
 
+#### `project init`
+
+テンプレート GitHub Project (Projects v2) を複製し、対象リポジトリにリンクします。
+
+```bash
+# git リポジトリ配下で実行（カレントの remote.origin.url から repo を自動検出）
+ghpp project init --token ghp_xxx --title "My Project"
+
+# リポジトリを明示
+ghpp project init --token ghp_xxx --title "My Project" --repo my-org/my-repo
+
+# 別 owner にプロジェクトを作る
+ghpp project init --token ghp_xxx --title "My Project" --owner other-org --repo my-org/my-repo
+
+# テンプレートを差し替え（デフォルト: douhashi/25）
+ghpp project init --title "My Project" --template-owner my-org --template-number 7
+
+# dry-run（API mutation を呼ばずに resolve のみ実行）
+ghpp project init --title "My Project" --dry-run
+
+# 同名プロジェクトがあっても作成（衝突チェックをスキップ）
+ghpp project init --title "My Project" --force
+```
+
+**動作の詳細:**
+
+1. 同名プロジェクトの有無をチェック（`--force` で省略可能）
+2. テンプレートプロジェクトと作成先 owner / リポジトリの GraphQL ノード ID を解決
+3. `copyProjectV2` でテンプレートを複製
+4. `linkProjectV2ToRepository` で対象リポジトリにリンク
+5. 新プロジェクトの workflow 一覧を取得
+6. JSON で結果を出力
+
+**フラグ一覧:**
+
+| フラグ | 環境変数 | 必須 | デフォルト値 | 説明 |
+|---|---|---|---|---|
+| `--token` | `GH_TOKEN` | Yes | - | GitHub API トークン（`project` write スコープと `repo` スコープが必要） |
+| `--title` | - | Yes | - | 新規プロジェクトのタイトル |
+| `--owner` | `GHPP_OWNER` | No | `--repo` の owner | プロジェクトを作成する user / org |
+| `--repo` | - | No | git remote から自動検出 | リンクするリポジトリ（`owner/name` 形式） |
+| `--template-owner` | `GHPP_TEMPLATE_OWNER` | No | `douhashi` | テンプレートプロジェクトの owner |
+| `--template-number` | `GHPP_TEMPLATE_NUMBER` | No | `25` | テンプレートプロジェクトの番号 |
+| `--force` | - | No | `false` | 同名プロジェクトが存在しても作成 |
+| `--dry-run` | - | No | `false` | API mutation を呼ばずに resolve のみ実行 |
+
+**出力例:**
+
+```json
+{
+  "dry_run": false,
+  "project": {
+    "id": "PVT_kwDOA...",
+    "number": 12,
+    "url": "https://github.com/users/my-org/projects/12",
+    "title": "My Project"
+  },
+  "linked_repository": "my-org/my-repo",
+  "workflows": [
+    { "name": "Item closed", "number": 1, "enabled": true },
+    { "name": "Auto-add to project", "number": 2, "enabled": false }
+  ],
+  "manual_setup_needed": [
+    "Auto-add to project: this workflow is NOT carried over by copyProjectV2. Open the new project's Workflows page and enable 'Auto-add to project' for the linked repository."
+  ]
+}
+```
+
+**トークンスコープ要件:**
+
+- `project`（write）スコープ: `copyProjectV2` と `linkProjectV2ToRepository` の実行に必須
+- `repo` スコープ: 対象リポジトリの ID 解決に必須
+
+スコープ不足の場合は、エラーメッセージにトークン更新ページの URL（<https://github.com/settings/tokens>）が含まれます。
+
+**テンプレート:**
+
+デフォルトテンプレート `douhashi/25` は、本ツールの想定するステータスフロー（inbox/plan/ready/doing）に対応した workflow 構成を持っています。独自テンプレートを使う場合は `--template-owner` / `--template-number` を指定してください。
+
+> **Note**: GitHub の `copyProjectV2` API は **"Auto-add to project" workflow を新プロジェクトにコピーしません**。出力 JSON の `manual_setup_needed` で案内されるとおり、新プロジェクトの Workflows 画面から手動で有効化してください。
+
 ## 設定
 
 パラメータは **コマンドラインフラグ** または **環境変数** で指定できます。

--- a/internal/cmd/project_init.go
+++ b/internal/cmd/project_init.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+	"github.com/douhashi/gh-project-promoter/internal/projectinit"
+)
+
+// RunProjectInit executes the project init workflow and prints the JSON
+// response to stdout.
+func RunProjectInit(ctx context.Context, cfg *config.ProjectInitConfig, init github.ProjectInitializer) error {
+	resp, err := projectinit.Run(ctx, cfg, init)
+	if err != nil {
+		return fmt.Errorf("failed to run project init: %w", err)
+	}
+
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	fmt.Println(string(out))
+	return nil
+}

--- a/internal/cmd/project_init_test.go
+++ b/internal/cmd/project_init_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// stubInitializer is a minimal github.ProjectInitializer for cmd-layer tests.
+type stubInitializer struct {
+	findErr      error
+	templateErr  error
+	ownerErr     error
+	repoErr      error
+	copyErr      error
+	linkErr      error
+	workflowsErr error
+}
+
+func (s *stubInitializer) GetProjectIDByOwnerAndNumber(_ context.Context, _ string, _ int) (string, error) {
+	return "PVT_t", s.templateErr
+}
+func (s *stubInitializer) GetOwnerID(_ context.Context, _ string) (string, error) {
+	return "U_o", s.ownerErr
+}
+func (s *stubInitializer) GetRepositoryID(_ context.Context, _, _ string) (string, error) {
+	return "R_r", s.repoErr
+}
+func (s *stubInitializer) FindProjectByTitle(_ context.Context, _, _ string) (*github.ExistingProject, error) {
+	return nil, s.findErr
+}
+func (s *stubInitializer) CopyProjectV2(_ context.Context, _, _, _ string) (*github.NewProject, error) {
+	if s.copyErr != nil {
+		return nil, s.copyErr
+	}
+	return &github.NewProject{ID: "PVT_n", Number: 5, URL: "https://example.com/5", Title: "T"}, nil
+}
+func (s *stubInitializer) LinkProjectV2ToRepository(_ context.Context, _, _ string) error {
+	return s.linkErr
+}
+func (s *stubInitializer) ListProjectV2Workflows(_ context.Context, _ string) ([]github.Workflow, error) {
+	if s.workflowsErr != nil {
+		return nil, s.workflowsErr
+	}
+	return []github.Workflow{{Name: "x", Number: 1, Enabled: true}}, nil
+}
+
+func baseCfg() *config.ProjectInitConfig {
+	return &config.ProjectInitConfig{
+		Token:          "tok",
+		Title:          "T",
+		Owner:          "o",
+		RepoOwner:      "o",
+		RepoName:       "r",
+		TemplateOwner:  "douhashi",
+		TemplateNumber: 25,
+	}
+}
+
+func TestRunProjectInit_Success(t *testing.T) {
+	if err := RunProjectInit(context.Background(), baseCfg(), &stubInitializer{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunProjectInit_DryRun(t *testing.T) {
+	cfg := baseCfg()
+	cfg.DryRun = true
+	if err := RunProjectInit(context.Background(), cfg, &stubInitializer{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunProjectInit_PropagatesError(t *testing.T) {
+	if err := RunProjectInit(context.Background(), baseCfg(), &stubInitializer{templateErr: errors.New("boom")}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/config/project_init.go
+++ b/internal/config/project_init.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/douhashi/gh-project-promoter/internal/gitutil"
+)
+
+const (
+	// DefaultTemplateOwner is the default owner whose project is used as the
+	// init template when --template-owner is not provided.
+	DefaultTemplateOwner = "douhashi"
+	// DefaultTemplateNumber is the project number used together with
+	// DefaultTemplateOwner.
+	DefaultTemplateNumber = 25
+)
+
+// ProjectInitConfig is the resolved configuration for `ghpp project init`.
+type ProjectInitConfig struct {
+	Token          string
+	Title          string
+	Owner          string // resolved (defaults to RepoOwner when --owner is not given)
+	RepoOwner      string
+	RepoName       string
+	TemplateOwner  string
+	TemplateNumber int
+	Force          bool
+	DryRun         bool
+}
+
+// LoadProjectInitWithArgs parses the flags for `ghpp project init`.
+// Resolution priority: flag > env > default.
+func LoadProjectInitWithArgs(args []string) (*ProjectInitConfig, error) {
+	fs := flag.NewFlagSet("ghpp project init", flag.ContinueOnError)
+
+	token := fs.String("token", "", "GitHub API token (env: GH_TOKEN)")
+	title := fs.String("title", "", "Title for the new project (required)")
+	owner := fs.String("owner", "", "Owner (user or org) under which to create the project (env: GHPP_OWNER, default: repo owner)")
+	repo := fs.String("repo", "", "owner/name of the repository to link (default: detected from current git remote)")
+	templateOwner := fs.String("template-owner", "", fmt.Sprintf("Template project owner (env: GHPP_TEMPLATE_OWNER, default: %s)", DefaultTemplateOwner))
+	templateNumber := fs.String("template-number", "", fmt.Sprintf("Template project number (env: GHPP_TEMPLATE_NUMBER, default: %d)", DefaultTemplateNumber))
+	force := fs.Bool("force", false, "Skip the same-title collision check")
+	dryRun := fs.Bool("dry-run", false, "Resolve everything but skip copy/link calls")
+
+	if args != nil {
+		if err := fs.Parse(args); err != nil {
+			return nil, fmt.Errorf("failed to parse flags: %w", err)
+		}
+	}
+
+	flagSet := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { flagSet[f.Name] = true })
+	resolve := func(flagName, flagVal, envKey, defaultVal string) string {
+		if flagSet[flagName] {
+			return flagVal
+		}
+		return getEnvOrDefault(envKey, defaultVal)
+	}
+
+	resolvedToken := resolve("token", *token, "GH_TOKEN", "")
+	if resolvedToken == "" {
+		return nil, fmt.Errorf("failed to load config: GH_TOKEN is required (use --token flag or GH_TOKEN env)")
+	}
+
+	if *title == "" {
+		return nil, fmt.Errorf("failed to load config: --title is required")
+	}
+
+	repoOwner, repoName, err := resolveRepo(flagSet["repo"], *repo)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedOwner := resolve("owner", *owner, "GHPP_OWNER", "")
+	if resolvedOwner == "" {
+		resolvedOwner = repoOwner
+	}
+
+	resolvedTemplateOwner := resolve("template-owner", *templateOwner, "GHPP_TEMPLATE_OWNER", DefaultTemplateOwner)
+	resolvedTemplateNumberStr := resolve("template-number", *templateNumber, "GHPP_TEMPLATE_NUMBER", strconv.Itoa(DefaultTemplateNumber))
+	resolvedTemplateNumber, err := strconv.Atoi(resolvedTemplateNumberStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template-number %q: %w", resolvedTemplateNumberStr, err)
+	}
+
+	return &ProjectInitConfig{
+		Token:          resolvedToken,
+		Title:          *title,
+		Owner:          resolvedOwner,
+		RepoOwner:      repoOwner,
+		RepoName:       repoName,
+		TemplateOwner:  resolvedTemplateOwner,
+		TemplateNumber: resolvedTemplateNumber,
+		Force:          *force,
+		DryRun:         *dryRun,
+	}, nil
+}
+
+// resolveRepo returns (owner, name) from the --repo flag or, if absent, from
+// the current working directory's git remote.
+func resolveRepo(repoFlagSet bool, repoFlag string) (string, string, error) {
+	if repoFlagSet && repoFlag != "" {
+		parts := strings.Split(repoFlag, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("--repo must be in 'owner/name' form, got %q", repoFlag)
+		}
+		return parts[0], parts[1], nil
+	}
+
+	owner, name, err := gitutil.GetCwdRepoFromGit()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to detect repository from git: %w. Pass --repo owner/name explicitly", err)
+	}
+	return owner, name, nil
+}

--- a/internal/config/project_init_test.go
+++ b/internal/config/project_init_test.go
@@ -1,0 +1,196 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// projectInitEnvKeys lists env keys touched by LoadProjectInitWithArgs.
+var projectInitEnvKeys = []string{
+	"GH_TOKEN",
+	"GHPP_OWNER",
+	"GHPP_TEMPLATE_OWNER",
+	"GHPP_TEMPLATE_NUMBER",
+}
+
+func clearProjectInitEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range projectInitEnvKeys {
+		t.Setenv(k, "")
+	}
+}
+
+func TestLoadProjectInitWithArgs_AllFlags(t *testing.T) {
+	clearProjectInitEnv(t)
+	cfg, err := LoadProjectInitWithArgs([]string{
+		"--token", "tok",
+		"--title", "My Project",
+		"--owner", "myorg",
+		"--repo", "myorg/myrepo",
+		"--template-owner", "tplowner",
+		"--template-number", "100",
+		"--force",
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Token != "tok" {
+		t.Errorf("Token = %q", cfg.Token)
+	}
+	if cfg.Title != "My Project" {
+		t.Errorf("Title = %q", cfg.Title)
+	}
+	if cfg.Owner != "myorg" || cfg.RepoOwner != "myorg" || cfg.RepoName != "myrepo" {
+		t.Errorf("owner/repo wrong: owner=%q repoOwner=%q repoName=%q", cfg.Owner, cfg.RepoOwner, cfg.RepoName)
+	}
+	if cfg.TemplateOwner != "tplowner" || cfg.TemplateNumber != 100 {
+		t.Errorf("template wrong: %s/%d", cfg.TemplateOwner, cfg.TemplateNumber)
+	}
+	if !cfg.Force || !cfg.DryRun {
+		t.Errorf("force/dry-run flags not picked up: force=%v dry=%v", cfg.Force, cfg.DryRun)
+	}
+}
+
+func TestLoadProjectInitWithArgs_TemplateDefaults(t *testing.T) {
+	clearProjectInitEnv(t)
+	cfg, err := LoadProjectInitWithArgs([]string{
+		"--token", "tok",
+		"--title", "X",
+		"--repo", "o/r",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TemplateOwner != "douhashi" || cfg.TemplateNumber != 25 {
+		t.Errorf("default template wrong: %s/%d", cfg.TemplateOwner, cfg.TemplateNumber)
+	}
+}
+
+func TestLoadProjectInitWithArgs_OwnerDefaultsToRepoOwner(t *testing.T) {
+	clearProjectInitEnv(t)
+	cfg, err := LoadProjectInitWithArgs([]string{
+		"--token", "tok",
+		"--title", "X",
+		"--repo", "alice/proj",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Owner != "alice" {
+		t.Errorf("Owner default = %q, want %q", cfg.Owner, "alice")
+	}
+}
+
+func TestLoadProjectInitWithArgs_OwnerOverridesRepoOwner(t *testing.T) {
+	clearProjectInitEnv(t)
+	cfg, err := LoadProjectInitWithArgs([]string{
+		"--token", "tok",
+		"--title", "X",
+		"--owner", "other-org",
+		"--repo", "alice/proj",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Owner != "other-org" {
+		t.Errorf("Owner = %q, want %q", cfg.Owner, "other-org")
+	}
+	if cfg.RepoOwner != "alice" || cfg.RepoName != "proj" {
+		t.Errorf("repo split wrong: %s/%s", cfg.RepoOwner, cfg.RepoName)
+	}
+}
+
+func TestLoadProjectInitWithArgs_EnvFallback(t *testing.T) {
+	clearProjectInitEnv(t)
+	t.Setenv("GH_TOKEN", "envtok")
+	t.Setenv("GHPP_OWNER", "envowner")
+	t.Setenv("GHPP_TEMPLATE_OWNER", "envtpl")
+	t.Setenv("GHPP_TEMPLATE_NUMBER", "77")
+	cfg, err := LoadProjectInitWithArgs([]string{
+		"--title", "X",
+		"--repo", "o/r",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Token != "envtok" {
+		t.Errorf("Token = %q", cfg.Token)
+	}
+	if cfg.Owner != "envowner" {
+		t.Errorf("Owner = %q", cfg.Owner)
+	}
+	if cfg.TemplateOwner != "envtpl" || cfg.TemplateNumber != 77 {
+		t.Errorf("template env not picked: %s/%d", cfg.TemplateOwner, cfg.TemplateNumber)
+	}
+}
+
+func TestLoadProjectInitWithArgs_MissingToken(t *testing.T) {
+	clearProjectInitEnv(t)
+	_, err := LoadProjectInitWithArgs([]string{"--title", "X", "--repo", "o/r"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "GH_TOKEN") {
+		t.Errorf("error should mention GH_TOKEN: %v", err)
+	}
+}
+
+func TestLoadProjectInitWithArgs_MissingTitle(t *testing.T) {
+	clearProjectInitEnv(t)
+	_, err := LoadProjectInitWithArgs([]string{"--token", "t", "--repo", "o/r"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "title") && !strings.Contains(err.Error(), "Title") {
+		t.Errorf("error should mention title: %v", err)
+	}
+}
+
+func TestLoadProjectInitWithArgs_BadRepoFormat(t *testing.T) {
+	clearProjectInitEnv(t)
+	_, err := LoadProjectInitWithArgs([]string{
+		"--token", "t",
+		"--title", "X",
+		"--repo", "no-slash",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "repo") {
+		t.Errorf("error should mention repo: %v", err)
+	}
+}
+
+func TestLoadProjectInitWithArgs_BadTemplateNumber(t *testing.T) {
+	clearProjectInitEnv(t)
+	_, err := LoadProjectInitWithArgs([]string{
+		"--token", "t",
+		"--title", "X",
+		"--repo", "o/r",
+		"--template-number", "abc",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLoadProjectInitWithArgs_RepoMissingOutsideGitDir(t *testing.T) {
+	// When --repo is omitted, gitutil tries `git config --get remote.origin.url`.
+	// Inside this test process the working directory IS a git repo, so we can't
+	// reliably test the failure here; instead we just ensure that the function
+	// either succeeds with the discovered repo or returns a clear error.
+	clearProjectInitEnv(t)
+	cfg, err := LoadProjectInitWithArgs([]string{"--token", "t", "--title", "X"})
+	if err != nil {
+		// In a non-git dir we expect a clear, actionable error.
+		if !strings.Contains(err.Error(), "--repo") && !strings.Contains(err.Error(), "repo") {
+			t.Errorf("error should mention repo: %v", err)
+		}
+		return
+	}
+	// In a git dir, owner/name must be populated.
+	if cfg.RepoOwner == "" || cfg.RepoName == "" {
+		t.Errorf("repo not auto-detected: %+v", cfg)
+	}
+}

--- a/internal/github/project_init.go
+++ b/internal/github/project_init.go
@@ -1,0 +1,297 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// ProjectInitializer abstracts the GraphQL operations needed to create a
+// project from a template and link it to a repository.
+type ProjectInitializer interface {
+	GetProjectIDByOwnerAndNumber(ctx context.Context, owner string, number int) (string, error)
+	GetOwnerID(ctx context.Context, owner string) (string, error)
+	GetRepositoryID(ctx context.Context, owner, name string) (string, error)
+	FindProjectByTitle(ctx context.Context, owner, title string) (*ExistingProject, error)
+	CopyProjectV2(ctx context.Context, templateProjectID, ownerID, title string) (*NewProject, error)
+	LinkProjectV2ToRepository(ctx context.Context, projectID, repositoryID string) error
+	ListProjectV2Workflows(ctx context.Context, projectID string) ([]Workflow, error)
+}
+
+// --- GetProjectIDByOwnerAndNumber ---
+
+type userProjectIDQuery struct {
+	User struct {
+		ProjectV2 struct {
+			ID string
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"user(login: $owner)"`
+}
+
+type orgProjectIDQuery struct {
+	Organization struct {
+		ProjectV2 struct {
+			ID string
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"organization(login: $owner)"`
+}
+
+// GetProjectIDByOwnerAndNumber resolves a ProjectV2 node ID from owner+number.
+// Tries user first, then organization.
+func (c *Client) GetProjectIDByOwnerAndNumber(ctx context.Context, owner string, number int) (string, error) {
+	vars := map[string]interface{}{
+		"owner":  githubv4.String(owner),
+		"number": githubv4.Int(number),
+	}
+	var uq userProjectIDQuery
+	userErr := c.inner.Query(ctx, &uq, vars)
+	if userErr == nil && uq.User.ProjectV2.ID != "" {
+		return uq.User.ProjectV2.ID, nil
+	}
+	var oq orgProjectIDQuery
+	orgErr := c.inner.Query(ctx, &oq, vars)
+	if orgErr == nil && oq.Organization.ProjectV2.ID != "" {
+		return oq.Organization.ProjectV2.ID, nil
+	}
+	return "", fmt.Errorf("failed to resolve project ID for %s/%d (tried user and org): user: %v, org: %v", owner, number, userErr, orgErr)
+}
+
+// --- GetOwnerID ---
+
+type userIDQuery struct {
+	User struct {
+		ID string
+	} `graphql:"user(login: $login)"`
+}
+
+type orgIDQuery struct {
+	Organization struct {
+		ID string
+	} `graphql:"organization(login: $login)"`
+}
+
+// GetOwnerID resolves the node ID of a user or organization.
+// Tries user first, then organization.
+func (c *Client) GetOwnerID(ctx context.Context, owner string) (string, error) {
+	vars := map[string]interface{}{"login": githubv4.String(owner)}
+	var uq userIDQuery
+	userErr := c.inner.Query(ctx, &uq, vars)
+	if userErr == nil && uq.User.ID != "" {
+		return uq.User.ID, nil
+	}
+	var oq orgIDQuery
+	orgErr := c.inner.Query(ctx, &oq, vars)
+	if orgErr == nil && oq.Organization.ID != "" {
+		return oq.Organization.ID, nil
+	}
+	return "", fmt.Errorf("failed to resolve owner ID for %q (tried user and org): user: %v, org: %v", owner, userErr, orgErr)
+}
+
+// --- GetRepositoryID ---
+
+type repositoryIDQuery struct {
+	Repository struct {
+		ID string
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// GetRepositoryID resolves the node ID of a repository.
+func (c *Client) GetRepositoryID(ctx context.Context, owner, name string) (string, error) {
+	var q repositoryIDQuery
+	vars := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+	}
+	if err := c.inner.Query(ctx, &q, vars); err != nil {
+		return "", fmt.Errorf("failed to resolve repository ID for %s/%s: %w", owner, name, err)
+	}
+	if q.Repository.ID == "" {
+		return "", fmt.Errorf("repository %s/%s not found or not accessible", owner, name)
+	}
+	return q.Repository.ID, nil
+}
+
+// --- FindProjectByTitle ---
+
+type projectListNode struct {
+	ID     string
+	Number int
+	URL    string `graphql:"url"`
+	Title  string
+}
+
+type userProjectListQuery struct {
+	User struct {
+		ProjectsV2 struct {
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   githubv4.String
+			}
+			Nodes []projectListNode
+		} `graphql:"projectsV2(first: 100, after: $cursor)"`
+	} `graphql:"user(login: $owner)"`
+}
+
+type orgProjectListQuery struct {
+	Organization struct {
+		ProjectsV2 struct {
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   githubv4.String
+			}
+			Nodes []projectListNode
+		} `graphql:"projectsV2(first: 100, after: $cursor)"`
+	} `graphql:"organization(login: $owner)"`
+}
+
+// FindProjectByTitle returns the first project owned by `owner` whose title
+// exactly matches `title`. Returns (nil, nil) when no match exists.
+// Tries user first, then organization.
+func (c *Client) FindProjectByTitle(ctx context.Context, owner, title string) (*ExistingProject, error) {
+	found, userErr := c.findUserProjectByTitle(ctx, owner, title)
+	if userErr == nil {
+		return found, nil
+	}
+	found, orgErr := c.findOrgProjectByTitle(ctx, owner, title)
+	if orgErr != nil {
+		return nil, fmt.Errorf("failed to list projects for %q (tried user and org): user: %v, org: %v", owner, userErr, orgErr)
+	}
+	return found, nil
+}
+
+func (c *Client) findUserProjectByTitle(ctx context.Context, owner, title string) (*ExistingProject, error) {
+	var cursor *githubv4.String
+	for {
+		var q userProjectListQuery
+		vars := map[string]interface{}{
+			"owner":  githubv4.String(owner),
+			"cursor": cursor,
+		}
+		if err := c.inner.Query(ctx, &q, vars); err != nil {
+			return nil, err
+		}
+		for _, n := range q.User.ProjectsV2.Nodes {
+			if n.Title == title {
+				return &ExistingProject{ID: n.ID, Number: n.Number, URL: n.URL, Title: n.Title}, nil
+			}
+		}
+		if !q.User.ProjectsV2.PageInfo.HasNextPage {
+			return nil, nil
+		}
+		cursor = &q.User.ProjectsV2.PageInfo.EndCursor
+	}
+}
+
+func (c *Client) findOrgProjectByTitle(ctx context.Context, owner, title string) (*ExistingProject, error) {
+	var cursor *githubv4.String
+	for {
+		var q orgProjectListQuery
+		vars := map[string]interface{}{
+			"owner":  githubv4.String(owner),
+			"cursor": cursor,
+		}
+		if err := c.inner.Query(ctx, &q, vars); err != nil {
+			return nil, err
+		}
+		for _, n := range q.Organization.ProjectsV2.Nodes {
+			if n.Title == title {
+				return &ExistingProject{ID: n.ID, Number: n.Number, URL: n.URL, Title: n.Title}, nil
+			}
+		}
+		if !q.Organization.ProjectsV2.PageInfo.HasNextPage {
+			return nil, nil
+		}
+		cursor = &q.Organization.ProjectsV2.PageInfo.EndCursor
+	}
+}
+
+// --- CopyProjectV2 ---
+
+type copyProjectV2Mutation struct {
+	CopyProjectV2 struct {
+		ProjectV2 struct {
+			ID     string
+			Number int
+			URL    string `graphql:"url"`
+			Title  string
+		}
+	} `graphql:"copyProjectV2(input: $input)"`
+}
+
+// CopyProjectV2 copies a template project to the given owner with a new title.
+func (c *Client) CopyProjectV2(ctx context.Context, templateProjectID, ownerID, title string) (*NewProject, error) {
+	var m copyProjectV2Mutation
+	include := githubv4.Boolean(false)
+	input := githubv4.CopyProjectV2Input{
+		ProjectID:          githubv4.ID(templateProjectID),
+		OwnerID:            githubv4.ID(ownerID),
+		Title:              githubv4.String(title),
+		IncludeDraftIssues: &include,
+	}
+	if err := c.inner.Mutate(ctx, &m, input, nil); err != nil {
+		return nil, fmt.Errorf("failed to copy project: %w", err)
+	}
+	return &NewProject{
+		ID:     m.CopyProjectV2.ProjectV2.ID,
+		Number: m.CopyProjectV2.ProjectV2.Number,
+		URL:    m.CopyProjectV2.ProjectV2.URL,
+		Title:  m.CopyProjectV2.ProjectV2.Title,
+	}, nil
+}
+
+// --- LinkProjectV2ToRepository ---
+
+type linkProjectV2ToRepositoryMutation struct {
+	LinkProjectV2ToRepository struct {
+		Repository struct {
+			ID string
+		}
+	} `graphql:"linkProjectV2ToRepository(input: $input)"`
+}
+
+// LinkProjectV2ToRepository links a ProjectV2 to a repository.
+func (c *Client) LinkProjectV2ToRepository(ctx context.Context, projectID, repositoryID string) error {
+	var m linkProjectV2ToRepositoryMutation
+	input := githubv4.LinkProjectV2ToRepositoryInput{
+		ProjectID:    githubv4.ID(projectID),
+		RepositoryID: githubv4.ID(repositoryID),
+	}
+	if err := c.inner.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("failed to link project to repository: %w", err)
+	}
+	return nil
+}
+
+// --- ListProjectV2Workflows ---
+
+type projectV2WorkflowsQuery struct {
+	Node struct {
+		ProjectV2 struct {
+			Workflows struct {
+				Nodes []struct {
+					Name    string
+					Number  int
+					Enabled bool
+				}
+			} `graphql:"workflows(first: 50)"`
+		} `graphql:"... on ProjectV2"`
+	} `graphql:"node(id: $id)"`
+}
+
+// ListProjectV2Workflows returns the workflows attached to a ProjectV2.
+func (c *Client) ListProjectV2Workflows(ctx context.Context, projectID string) ([]Workflow, error) {
+	var q projectV2WorkflowsQuery
+	vars := map[string]interface{}{"id": githubv4.ID(projectID)}
+	if err := c.inner.Query(ctx, &q, vars); err != nil {
+		return nil, fmt.Errorf("failed to list project workflows: %w", err)
+	}
+	out := make([]Workflow, 0, len(q.Node.ProjectV2.Workflows.Nodes))
+	for _, n := range q.Node.ProjectV2.Workflows.Nodes {
+		out = append(out, Workflow{Name: n.Name, Number: n.Number, Enabled: n.Enabled})
+	}
+	return out, nil
+}
+
+// Compile-time check that Client implements ProjectInitializer.
+var _ ProjectInitializer = (*Client)(nil)

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -106,3 +106,35 @@ type DemoteResponse struct {
 	Summary DemoteSummary `json:"summary"`
 	Phases  DemotePhases  `json:"phases"`
 }
+
+// ExistingProject represents a project found by title lookup.
+type ExistingProject struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+}
+
+// NewProject is the result of a copyProjectV2 call.
+type NewProject struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+}
+
+// Workflow represents a single workflow on a ProjectV2.
+type Workflow struct {
+	Name    string `json:"name"`
+	Number  int    `json:"number"`
+	Enabled bool   `json:"enabled"`
+}
+
+// ProjectInitResponse is the top-level JSON output of `project init`.
+type ProjectInitResponse struct {
+	DryRun            bool       `json:"dry_run"`
+	Project           NewProject `json:"project"`
+	LinkedRepository  string     `json:"linked_repository"`
+	Workflows         []Workflow `json:"workflows"`
+	ManualSetupNeeded []string   `json:"manual_setup_needed"`
+}

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -1,0 +1,70 @@
+// Package gitutil provides helpers for parsing git remote URLs and detecting
+// the current repository owner/name.
+package gitutil
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ParseRemoteURL extracts owner and repository name from a git remote URL.
+// Supported forms:
+//   - https://github.com/owner/repo(.git)?
+//   - git@github.com:owner/repo(.git)?
+//   - ssh://git@github.com/owner/repo(.git)?
+func ParseRemoteURL(rawURL string) (owner, name string, err error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("empty remote URL")
+	}
+
+	// Strip protocol/user prefix down to "host[:/]owner/repo"
+	var path string
+	switch {
+	case strings.HasPrefix(trimmed, "https://"):
+		path = strings.TrimPrefix(trimmed, "https://")
+	case strings.HasPrefix(trimmed, "http://"):
+		path = strings.TrimPrefix(trimmed, "http://")
+	case strings.HasPrefix(trimmed, "ssh://"):
+		path = strings.TrimPrefix(trimmed, "ssh://")
+		if at := strings.Index(path, "@"); at >= 0 {
+			path = path[at+1:]
+		}
+	case strings.HasPrefix(trimmed, "git@"):
+		// SCP-like syntax: git@host:owner/repo
+		path = strings.TrimPrefix(trimmed, "git@")
+	default:
+		return "", "", fmt.Errorf("unsupported remote URL format: %q", rawURL)
+	}
+
+	// After this point `path` is "host[:/]owner/repo[.git]"
+	// Normalize the host separator (':' for SCP-like) into '/'.
+	path = strings.Replace(path, ":", "/", 1)
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("could not extract owner/repo from URL: %q", rawURL)
+	}
+	owner = parts[1]
+	name = strings.TrimSuffix(parts[2], ".git")
+	if owner == "" || name == "" {
+		return "", "", fmt.Errorf("could not extract owner/repo from URL: %q", rawURL)
+	}
+	return owner, name, nil
+}
+
+// GetCwdRepoFromGit reads `git config --get remote.origin.url` for the
+// current working directory and returns the parsed owner/repo.
+func GetCwdRepoFromGit() (owner, name string, err error) {
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	out, runErr := cmd.Output()
+	if runErr != nil {
+		// Distinguish "git not installed" from "ran but failed".
+		if _, lookErr := exec.LookPath("git"); lookErr != nil {
+			return "", "", fmt.Errorf("git command not found: %w", lookErr)
+		}
+		return "", "", fmt.Errorf("failed to read git remote (not a git repository?): %w", runErr)
+	}
+	return ParseRemoteURL(string(out))
+}

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -1,0 +1,94 @@
+package gitutil
+
+import "testing"
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantName  string
+		wantErr   bool
+	}{
+		{
+			name:      "https without .git",
+			input:     "https://github.com/owner/repo",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+		{
+			name:      "https with .git suffix",
+			input:     "https://github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+		{
+			name:      "https with trailing newline",
+			input:     "https://github.com/owner/repo.git\n",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+		{
+			name:      "scp-like ssh",
+			input:     "git@github.com:owner/repo.git",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+		{
+			name:      "scp-like ssh without .git",
+			input:     "git@github.com:owner/repo",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+		{
+			name:      "ssh:// form",
+			input:     "ssh://git@github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported scheme",
+			input:   "ftp://github.com/owner/repo",
+			wantErr: true,
+		},
+		{
+			name:    "missing owner/repo",
+			input:   "https://github.com/",
+			wantErr: true,
+		},
+		{
+			name:    "owner only",
+			input:   "https://github.com/owner",
+			wantErr: true,
+		},
+		{
+			name:      "extra path segments are ignored beyond owner/repo",
+			input:     "https://github.com/owner/repo/extra",
+			wantOwner: "owner",
+			wantName:  "repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, name, err := ParseRemoteURL(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got owner=%q name=%q", owner, name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner || name != tt.wantName {
+				t.Errorf("got (%q, %q), want (%q, %q)", owner, name, tt.wantOwner, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/projectinit/init.go
+++ b/internal/projectinit/init.go
@@ -1,0 +1,114 @@
+// Package projectinit implements the business logic for `ghpp project init`:
+// copying a template ProjectV2 into a target owner and linking it to a repo.
+package projectinit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// autoAddManualHint is always returned in ManualSetupNeeded because the
+// "Auto-add to project" workflow is not transferred by copyProjectV2.
+const autoAddManualHint = "Auto-add to project: this workflow is NOT carried over by copyProjectV2. Open the new project's Workflows page and enable 'Auto-add to project' for the linked repository."
+
+// dryRunPlaceholder marks fields whose real values would only be known after
+// the API mutations run. It is visually distinct so JSON consumers cannot
+// confuse it with a real GraphQL node ID.
+const dryRunPlaceholder = "<dry-run>"
+
+// Run executes the project init workflow and returns the response that
+// callers will marshal to JSON.
+func Run(ctx context.Context, cfg *config.ProjectInitConfig, init github.ProjectInitializer) (*github.ProjectInitResponse, error) {
+	repoFullName := cfg.RepoOwner + "/" + cfg.RepoName
+
+	// 1. Pre-flight collision check (skippable with --force).
+	if !cfg.Force {
+		existing, err := init.FindProjectByTitle(ctx, cfg.Owner, cfg.Title)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check for existing project with title %q: %w", cfg.Title, err)
+		}
+		if existing != nil {
+			return nil, fmt.Errorf("project with title %q already exists at %s (#%d). Use --force to create a new project with the same title", cfg.Title, existing.URL, existing.Number)
+		}
+	}
+
+	// 2. Resolve template / owner / repository node IDs in parallel sequence.
+	templateID, err := init.GetProjectIDByOwnerAndNumber(ctx, cfg.TemplateOwner, cfg.TemplateNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access template project (%s/%d): %w", cfg.TemplateOwner, cfg.TemplateNumber, err)
+	}
+
+	ownerID, err := init.GetOwnerID(ctx, cfg.Owner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve owner %q: %w", cfg.Owner, err)
+	}
+
+	repoID, err := init.GetRepositoryID(ctx, cfg.RepoOwner, cfg.RepoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repository %s: %w", repoFullName, err)
+	}
+
+	// 3. Dry-run short-circuit: skip all mutations and list calls but keep
+	//    the JSON shape stable so consumers can branch on `dry_run` only.
+	if cfg.DryRun {
+		return &github.ProjectInitResponse{
+			DryRun: true,
+			Project: github.NewProject{
+				ID:     dryRunPlaceholder,
+				Number: 0,
+				URL:    "",
+				Title:  cfg.Title,
+			},
+			LinkedRepository:  repoFullName,
+			Workflows:         []github.Workflow{},
+			ManualSetupNeeded: []string{autoAddManualHint},
+		}, nil
+	}
+
+	// 4. Copy the template project.
+	newProj, err := init.CopyProjectV2(ctx, templateID, ownerID, cfg.Title)
+	if err != nil {
+		return nil, augmentScopeError(fmt.Errorf("failed to copy template project: %w", err))
+	}
+
+	// 5. Link the new project to the target repository. If this fails, the
+	//    project is already created, so we surface its URL/number for recovery.
+	if err := init.LinkProjectV2ToRepository(ctx, newProj.ID, repoID); err != nil {
+		return nil, fmt.Errorf("project created (#%d, %s) but failed to link repository %s: %w",
+			newProj.Number, newProj.URL, repoFullName, err)
+	}
+
+	// 6. Fetch workflows so callers can verify that the expected automations
+	//    came over with the copy.
+	workflows, err := init.ListProjectV2Workflows(ctx, newProj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("project created (#%d) and linked, but failed to fetch workflows: %w", newProj.Number, err)
+	}
+
+	return &github.ProjectInitResponse{
+		DryRun:            false,
+		Project:           *newProj,
+		LinkedRepository:  repoFullName,
+		Workflows:         workflows,
+		ManualSetupNeeded: []string{autoAddManualHint},
+	}, nil
+}
+
+// augmentScopeError detects GraphQL error strings that hint at missing OAuth
+// scopes and rewrites them with a concrete remediation step.
+func augmentScopeError(err error) error {
+	msg := err.Error()
+	low := strings.ToLower(msg)
+	scopeHint := strings.Contains(low, "insufficient_scopes") ||
+		strings.Contains(low, "required scope") ||
+		strings.Contains(low, "403") ||
+		strings.Contains(low, "not accessible")
+	if scopeHint {
+		return fmt.Errorf("%w. Token requires the 'project' (write) scope. Update your token at https://github.com/settings/tokens", err)
+	}
+	return err
+}

--- a/internal/projectinit/init_test.go
+++ b/internal/projectinit/init_test.go
@@ -1,0 +1,319 @@
+package projectinit
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/douhashi/gh-project-promoter/internal/config"
+	"github.com/douhashi/gh-project-promoter/internal/github"
+)
+
+// fakeInitializer is a configurable test double for github.ProjectInitializer
+// that records call counts and returns canned values.
+type fakeInitializer struct {
+	// canned responses
+	templateID    string
+	templateIDErr error
+
+	ownerID    string
+	ownerIDErr error
+
+	repoID    string
+	repoIDErr error
+
+	existing    *github.ExistingProject
+	existingErr error
+
+	newProject    *github.NewProject
+	newProjectErr error
+
+	linkErr error
+
+	workflows    []github.Workflow
+	workflowsErr error
+
+	// call counters
+	calls struct {
+		getProjectID  int
+		getOwnerID    int
+		getRepoID     int
+		findByTitle   int
+		copyProject   int
+		linkRepo      int
+		listWorkflows int
+	}
+}
+
+func (f *fakeInitializer) GetProjectIDByOwnerAndNumber(_ context.Context, _ string, _ int) (string, error) {
+	f.calls.getProjectID++
+	return f.templateID, f.templateIDErr
+}
+
+func (f *fakeInitializer) GetOwnerID(_ context.Context, _ string) (string, error) {
+	f.calls.getOwnerID++
+	return f.ownerID, f.ownerIDErr
+}
+
+func (f *fakeInitializer) GetRepositoryID(_ context.Context, _, _ string) (string, error) {
+	f.calls.getRepoID++
+	return f.repoID, f.repoIDErr
+}
+
+func (f *fakeInitializer) FindProjectByTitle(_ context.Context, _, _ string) (*github.ExistingProject, error) {
+	f.calls.findByTitle++
+	return f.existing, f.existingErr
+}
+
+func (f *fakeInitializer) CopyProjectV2(_ context.Context, _, _, _ string) (*github.NewProject, error) {
+	f.calls.copyProject++
+	return f.newProject, f.newProjectErr
+}
+
+func (f *fakeInitializer) LinkProjectV2ToRepository(_ context.Context, _, _ string) error {
+	f.calls.linkRepo++
+	return f.linkErr
+}
+
+func (f *fakeInitializer) ListProjectV2Workflows(_ context.Context, _ string) ([]github.Workflow, error) {
+	f.calls.listWorkflows++
+	return f.workflows, f.workflowsErr
+}
+
+func defaultCfg() *config.ProjectInitConfig {
+	return &config.ProjectInitConfig{
+		Token:          "tok",
+		Title:          "My Project",
+		Owner:          "myorg",
+		RepoOwner:      "myorg",
+		RepoName:       "myrepo",
+		TemplateOwner:  "douhashi",
+		TemplateNumber: 25,
+	}
+}
+
+func happyInitializer() *fakeInitializer {
+	return &fakeInitializer{
+		templateID: "PVT_template",
+		ownerID:    "U_owner",
+		repoID:     "R_repo",
+		existing:   nil,
+		newProject: &github.NewProject{
+			ID:     "PVT_new",
+			Number: 99,
+			URL:    "https://github.com/users/myorg/projects/99",
+			Title:  "My Project",
+		},
+		workflows: []github.Workflow{
+			{Name: "Item closed", Number: 1, Enabled: true},
+			{Name: "Auto-add to project", Number: 2, Enabled: false},
+		},
+	}
+}
+
+func TestRun_Happy(t *testing.T) {
+	f := happyInitializer()
+	resp, err := Run(context.Background(), defaultCfg(), f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.DryRun {
+		t.Errorf("DryRun = true, want false")
+	}
+	if resp.Project.ID != "PVT_new" || resp.Project.Number != 99 {
+		t.Errorf("unexpected project: %+v", resp.Project)
+	}
+	if resp.LinkedRepository != "myorg/myrepo" {
+		t.Errorf("LinkedRepository = %q, want %q", resp.LinkedRepository, "myorg/myrepo")
+	}
+	if len(resp.Workflows) != 2 {
+		t.Errorf("got %d workflows, want 2", len(resp.Workflows))
+	}
+	if len(resp.ManualSetupNeeded) == 0 {
+		t.Fatalf("ManualSetupNeeded must not be empty")
+	}
+	// V12: Auto-add hint must always be present.
+	joined := strings.Join(resp.ManualSetupNeeded, "\n")
+	if !strings.Contains(joined, "Auto-add to project") {
+		t.Errorf("ManualSetupNeeded missing Auto-add hint: %v", resp.ManualSetupNeeded)
+	}
+	// Verify call counts (V10 baseline: real run hits all 6 surfaces).
+	if f.calls.findByTitle != 1 {
+		t.Errorf("findByTitle calls = %d, want 1", f.calls.findByTitle)
+	}
+	if f.calls.copyProject != 1 || f.calls.linkRepo != 1 || f.calls.listWorkflows != 1 {
+		t.Errorf("expected one of each (copy/link/list), got copy=%d link=%d list=%d",
+			f.calls.copyProject, f.calls.linkRepo, f.calls.listWorkflows)
+	}
+}
+
+func TestRun_DryRunSkipsMutations(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.DryRun = true
+	f := happyInitializer()
+
+	resp, err := Run(context.Background(), cfg, f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// V10: copy/link/list must not be called.
+	if f.calls.copyProject != 0 {
+		t.Errorf("copyProject called %d times in dry-run", f.calls.copyProject)
+	}
+	if f.calls.linkRepo != 0 {
+		t.Errorf("linkRepo called %d times in dry-run", f.calls.linkRepo)
+	}
+	if f.calls.listWorkflows != 0 {
+		t.Errorf("listWorkflows called %d times in dry-run", f.calls.listWorkflows)
+	}
+
+	if !resp.DryRun {
+		t.Errorf("DryRun = false, want true")
+	}
+	if resp.Project.Title != "My Project" {
+		t.Errorf("Project.Title = %q, want %q", resp.Project.Title, "My Project")
+	}
+	if resp.Project.ID != "<dry-run>" {
+		t.Errorf("Project.ID = %q, want %q", resp.Project.ID, "<dry-run>")
+	}
+	if resp.Workflows == nil {
+		t.Errorf("Workflows must be non-nil empty slice for stable JSON")
+	}
+	if len(resp.ManualSetupNeeded) == 0 {
+		t.Errorf("ManualSetupNeeded must include guidance even in dry-run")
+	}
+}
+
+func TestRun_NameCollisionWithoutForce(t *testing.T) {
+	f := happyInitializer()
+	f.existing = &github.ExistingProject{
+		ID:     "PVT_existing",
+		Number: 7,
+		URL:    "https://github.com/users/myorg/projects/7",
+		Title:  "My Project",
+	}
+
+	_, err := Run(context.Background(), defaultCfg(), f)
+	if err == nil {
+		t.Fatal("expected error on name collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention already exists: %v", err)
+	}
+	if !strings.Contains(err.Error(), "#7") {
+		t.Errorf("error should include existing project number: %v", err)
+	}
+	if f.calls.copyProject != 0 {
+		t.Errorf("copyProject must not be called on collision")
+	}
+}
+
+func TestRun_ForceSkipsCollisionCheck(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.Force = true
+	f := happyInitializer()
+	// Even if existing returned, force skips the lookup entirely.
+	f.existing = &github.ExistingProject{ID: "PVT_existing", Number: 7, URL: "", Title: "My Project"}
+
+	_, err := Run(context.Background(), cfg, f)
+	if err != nil {
+		t.Fatalf("unexpected error with --force: %v", err)
+	}
+	if f.calls.findByTitle != 0 {
+		t.Errorf("findByTitle should not be called when force=true (got %d)", f.calls.findByTitle)
+	}
+	if f.calls.copyProject != 1 {
+		t.Errorf("copyProject calls = %d, want 1", f.calls.copyProject)
+	}
+}
+
+func TestRun_TemplateNotFound(t *testing.T) {
+	f := happyInitializer()
+	f.templateID = ""
+	f.templateIDErr = errors.New("not found")
+
+	_, err := Run(context.Background(), defaultCfg(), f)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "template") {
+		t.Errorf("error should mention template: %v", err)
+	}
+}
+
+func TestRun_CopyFailsWithInsufficientScope(t *testing.T) {
+	// V5: when the API hints at insufficient scopes, surface a helpful message.
+	cases := []string{
+		"INSUFFICIENT_SCOPES: 403 Resource not accessible by integration",
+		// Real-world GitHub GraphQL error string (token without 'project' scope).
+		"Your token has not been granted the required scopes to execute this query. The 'copyProjectV2' field requires one of the following scopes: ['project']",
+	}
+	for _, msg := range cases {
+		f := happyInitializer()
+		f.newProject = nil
+		f.newProjectErr = errors.New(msg)
+
+		_, err := Run(context.Background(), defaultCfg(), f)
+		if err == nil {
+			t.Fatalf("expected error, got nil (msg=%q)", msg)
+		}
+		if !strings.Contains(err.Error(), "project") || !strings.Contains(err.Error(), "scope") {
+			t.Errorf("error should mention project scope (msg=%q): %v", msg, err)
+		}
+		if !strings.Contains(err.Error(), "https://github.com/settings/tokens") {
+			t.Errorf("error should include token settings URL (msg=%q): %v", msg, err)
+		}
+	}
+}
+
+func TestRun_LinkFailsAfterCopy(t *testing.T) {
+	f := happyInitializer()
+	f.linkErr = errors.New("link failed")
+
+	_, err := Run(context.Background(), defaultCfg(), f)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Must mention that the project was created so the user can recover.
+	if !strings.Contains(err.Error(), "#99") || !strings.Contains(err.Error(), "link") {
+		t.Errorf("error should reference created project number and link failure: %v", err)
+	}
+}
+
+func TestRun_OrgFallbackForOwner(t *testing.T) {
+	// V11: ownerID resolution failures bubble up; both user/org are tried inside
+	// the GitHub client, so here we just assert that an owner lookup error
+	// surfaces cleanly.
+	f := happyInitializer()
+	f.ownerID = ""
+	f.ownerIDErr = errors.New("owner not found in user nor org")
+
+	_, err := Run(context.Background(), defaultCfg(), f)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "owner") {
+		t.Errorf("error should mention owner: %v", err)
+	}
+}
+
+func TestRun_ManualSetupAlwaysPresent(t *testing.T) {
+	// V12: Auto-add hint must be present in both real and dry-run flows.
+	f := happyInitializer()
+	resp, err := Run(context.Background(), defaultCfg(), f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasHint := false
+	for _, m := range resp.ManualSetupNeeded {
+		if strings.Contains(m, "Auto-add") {
+			hasHint = true
+			break
+		}
+	}
+	if !hasHint {
+		t.Errorf("ManualSetupNeeded missing auto-add hint: %v", resp.ManualSetupNeeded)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,39 +21,75 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		fmt.Println("ghpp - GitHub Project Promoter")
-		fmt.Println("Usage: ghpp <command>")
-		fmt.Println("Commands: promote, demote")
+		printUsage()
 		return
 	}
 
-	subArgs := os.Args[2:]
-
 	switch os.Args[1] {
 	case "promote":
-		cfg, err := config.LoadWithArgs(subArgs)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
-		}
-		client := github.NewClient(cfg.Token)
-		if err := cmd.RunPromote(context.Background(), cfg, client); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
-		}
+		runPromote(os.Args[2:])
 	case "demote":
-		cfg, err := config.LoadWithArgs(subArgs)
+		runDemote(os.Args[2:])
+	case "project":
+		runProject(os.Args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Println("ghpp - GitHub Project Promoter")
+	fmt.Println("Usage: ghpp <command> [flags]")
+	fmt.Println("Commands: promote, demote, project init")
+}
+
+func runPromote(args []string) {
+	cfg, err := config.LoadWithArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	client := github.NewClient(cfg.Token)
+	if err := cmd.RunPromote(context.Background(), cfg, client); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runDemote(args []string) {
+	cfg, err := config.LoadWithArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	client := github.NewClient(cfg.Token)
+	if err := cmd.RunDemote(context.Background(), cfg, client); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runProject(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: ghpp project <subcommand> [flags]")
+		fmt.Fprintln(os.Stderr, "Subcommands: init")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "init":
+		cfg, err := config.LoadProjectInitWithArgs(args[1:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
 		client := github.NewClient(cfg.Token)
-		if err := cmd.RunDemote(context.Background(), cfg, client); err != nil {
+		if err := cmd.RunProjectInit(context.Background(), cfg, client); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		fmt.Fprintf(os.Stderr, "unknown project subcommand: %s\n", args[0])
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Closes #54

## 変更内容

GitHub Projects v2 のセットアップを CLI から自動化する `ghpp project init` サブコマンドを追加。テンプレートプロジェクト (デフォルト: `douhashi/25`) を `copyProjectV2` で複製し、リポジトリへの `linkProjectV2ToRepository` まで一括実行する。

### 主要追加ファイル

| パス | 責務 |
|---|---|
| `internal/gitutil/` | git remote URL から `owner/repo` を抽出 (HTTPS / SSH 両対応) |
| `internal/github/project_init.go` | `ProjectInitializer` インターフェース + 7 GraphQL 操作 (user/org 両対応) |
| `internal/projectinit/init.go` | ビジネスロジック (collision check / dry-run 分岐 / scope error 補強) |
| `internal/config/project_init.go` | `LoadProjectInitWithArgs` (既存 `LoadWithArgs` と分離、回帰リスクゼロ) |
| `internal/cmd/project_init.go` | `RunProjectInit` エントリポイント (JSON 出力) |
| `main.go` | 2階層サブコマンドディスパッチ (`project init`) |
| `internal/github/types.go` | `ExistingProject` / `NewProject` / `Workflow` / `ProjectInitResponse` 型を追加 |
| `README.md` | `project init` の使い方・フラグ・出力サンプル・トークンスコープ要件を追記 |

### 動作フロー

1. cwd の git remote から `owner/repo` 自動検出（`--repo` で上書き可）
2. 同名プロジェクト存在チェック（`--force` で続行可、既存ならエラー）
3. テンプレートを `copyProjectV2` で複製（user/org 両対応のフォールバック）
4. `linkProjectV2ToRepository` でリンク
5. 新規プロジェクトのワークフロー一覧取得 + `manual_setup_needed` に Auto-add 案内
6. JSON 出力（既存 promote/demote と同形式）

### 設計判断

実装計画フェーズで 3 論点を PO エージェントが判定（すべて planner 推奨と一致）:
- `ProjectInitializer` IF を `internal/github/client.go` に並置（既存 `ItemPromoter` パターン踏襲）
- dry-run の `Project` フィールドはダミー値で出力（既存 promote/demote の dry-run スキーマと整合）
- `LoadProjectInitWithArgs` を別関数化（既存 `LoadWithArgs` への回帰リスクゼロ）

### テスト

- 全 121 テスト pass（既存 + 新規）
- `gofmt` clean / `go vet` 無警告 / `golangci-lint` 無警告
- `--dry-run` での実機スモーク試験完了
- 実機 GraphQL schema を `gh api graphql` で確認 (V1-V3)
- スコープ不足時のエラーメッセージ補強を実機トークンで確認 (V5)

### 既知の制約

- Projects v2 ワークフローは GraphQL/REST で create/update/enable できない（公式制約）。Auto-add to project は `copyProjectV2` でコピー対象外のため、`manual_setup_needed` で手動有効化を案内
- 実行には GitHub token に `project` (write) スコープと `repo` スコープが必要
- テンプレート参照のデフォルト `douhashi/25` は public visibility 維持が前提

🤖 Generated with [Claude Code](https://claude.com/claude-code)