### PR TITLE
Implement #58: Add --workflow=full|simple flag for two-mode workflow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,31 @@ GitHub Projects をベースにした、プロジェクト進行ワークフロ�
 
 ## ステータスフロー
 
+GHPP は2つのワークフローモードを提供します。
+
+### `full` モード（デフォルト）
+
 ```
 inbox → plan → ready → doing
 ```
 
-GHPP は上記フローのうち、以下2つの昇格を自動化します。
-
 | フェーズ | 遷移 | 制約 |
 |---|---|---|
 | **計画フェーズ** | `inbox` → `plan` | 一度に昇格する個数に上限あり（デフォルト: 3） |
+| **準備フェーズ** | `plan` → `ready` | 指定ラベル付きの Issue のみ（デフォルト無効） |
 | **実行フェーズ** | `ready` → `doing` | リポジトリ単位で1つまで |
+
+### `simple` モード
+
+```
+inbox → doing
+```
+
+| フェーズ | 遷移 | 制約 |
+|---|---|---|
+| **実行フェーズ** | `inbox` → `doing` | リポジトリ単位で1つまで |
+
+`--workflow=simple`（または `GHPP_WORKFLOW=simple`）で切り替え。Plan / Ready ステータスは使用しません。
 
 ## インストール
 
@@ -52,6 +67,9 @@ ghpp promote --plan-limit 5
 
 # ステータス名をカスタマイズ
 ghpp promote --status-inbox "Todo" --status-plan "Planned"
+
+# simple モード（Backlog → In progress の1段階のみ）
+ghpp promote --workflow simple
 ```
 
 **動作の詳細:**
@@ -199,6 +217,7 @@ ghpp project init --title "My Project" --force
 | `--promote-plan-enabled` | `GHPP_PROMOTE_PLAN_ENABLED` | No | `true` | 計画フェーズ (backlog→plan) の自動昇格を有効化 |
 | `--promote-ready-enabled` | `GHPP_PROMOTE_READY_ENABLED` | No | `false` | 準備フェーズ (plan→ready) の自動昇格を有効化（ラベルゲート） |
 | `--planned-label` | `GHPP_PLANNED_LABEL` | No | `planned` | 準備フェーズの昇格トリガーとなるラベル名 |
+| `--workflow` | `GHPP_WORKFLOW` | No | `full` | ワークフローモード（`full` / `simple`）。`simple` は Backlog と In progress の2状態のみで運用 |
 
 > **セキュリティに関する注意**: `--token` でトークンを渡すと、プロセス一覧やシェル履歴にトークンが残る可能性があります。環境変数 `GH_TOKEN` または `.env` ファイルでの指定を推奨します。
 

--- a/docs/business/model.md
+++ b/docs/business/model.md
@@ -1,6 +1,19 @@
 # Promote ライフサイクル
 
-## ステータスフロー
+## ワークフローモード
+
+GHPP は2つのワークフローモードを提供する。
+
+| モード | 自動遷移 | 使用するステータス | デフォルト |
+|---|---|---|---|
+| `full` | `inbox → plan → ready → doing` の3段階 | inbox / plan / ready / doing | ✓ |
+| `simple` | `inbox → doing` の1段階 | inbox / doing |  |
+
+`--workflow` フラグまたは `GHPP_WORKFLOW` 環境変数で切り替える。
+
+> **以下「1. 計画フェーズ」「2. 準備フェーズ」「3. 実行フェーズ」は `full` モードの仕様**。`simple` モードについては末尾の「Simple モード仕様」を参照。
+
+## ステータスフロー（full モード）
 
 ```
 inbox → plan → ready → doing
@@ -172,3 +185,46 @@ demote コマンドは stale（更新から一定時間経過）なアイテム�
 
 - `phases.doing` は常にキーが存在する（0件でも省略されない）
 - `results.demoted` / `results.skipped` は0件の場合 `[]`（`null` ではない）
+
+> **simple モードでの降格先は `Backlog`（=inbox）**。降格先以外の挙動（stale 判定など）は `full` モードと同一。
+
+---
+
+## Simple モード仕様
+
+`--workflow=simple` を指定すると、`inbox` と `doing` の2ステータスのみで運用するモードに切り替わる。
+
+### 自動遷移
+
+- promote: `Backlog → In progress`（plan / ready フェーズはスキップ）
+- demote: stale な doing は `Backlog` に降格
+
+### フラグの扱い
+
+| フラグ | simple モードでの扱い |
+|---|---|
+| `--promote-plan-enabled` | silently 無視（warning は出さない） |
+| `--promote-ready-enabled` | silently 無視（warning は出さない） |
+| `--planned-label` | silently 無視（warning は出さない） |
+| `--plan-limit` | silently 無視（plan フェーズが走らないため） |
+| `--stale-threshold` | full モードと同一の挙動 |
+| `--dry-run` | full モードと同一の挙動 |
+
+### 制約
+
+- 「リポジトリ単位で1つまで」ルールは維持される（doing に既存アイテムがあるリポジトリの Backlog はスキップされる）
+
+### 出力 JSON
+
+`phases.plan` / `phases.ready` キーは省略されず、`promoted` / `skipped` がそれぞれ空配列で出力される。
+これにより full / simple 両モードで同一スキーマを保つ。
+
+```json
+{
+  "phases": {
+    "plan":  { "summary": { "promoted": 0, "skipped": 0, "total": 0 }, "results": { "promoted": [], "skipped": [] } },
+    "ready": { "summary": { "promoted": 0, "skipped": 0, "total": 0 }, "results": { "promoted": [], "skipped": [] } },
+    "doing": { "summary": { "promoted": 1, "skipped": 0, "total": 1 }, "results": { "promoted": [...], "skipped": [] } }
+  }
+}
+```

--- a/docs/business/overview.md
+++ b/docs/business/overview.md
@@ -25,6 +25,7 @@ GitHub Projects のステータス管理を手動で行う運用コストを削�
 | `GHPP_STATUS_READY` | `Ready` | ready に対応するステータス名 |
 | `GHPP_STATUS_DOING` | `In progress` | doing に対応するステータス名 |
 | `GHPP_PLAN_LIMIT` | `3` | 計画フェーズで一度に昇格する上限数 |
+| `GHPP_WORKFLOW` | `full` | ワークフローモード（`full` / `simple`）。`simple` は Backlog と In progress のみで運用 |
 
 ## 設定ファイル
 

--- a/docs/development/guideline.md
+++ b/docs/development/guideline.md
@@ -36,9 +36,12 @@
 
 ```
 ghpp promote [flags]
+  --workflow <full|simple>      ワークフローモード (env: GHPP_WORKFLOW, default: full)
   --promote-ready-enabled       plan→ready自動昇格を有効化する (env: GHPP_PROMOTE_READY_ENABLED, default: false)
   --planned-label <label>       plan→ready昇格トリガーとなるラベル名 (env: GHPP_PLANNED_LABEL, default: planned)
 ```
+
+`--workflow=simple` を指定すると Backlog → In progress の1段階のみで運用する。詳細は `docs/business/model.md` の「Simple モード仕様」を参照。
 
 ### demote
 
@@ -46,9 +49,12 @@ ghpp promote [flags]
 
 ```
 ghpp demote [flags]
+  --workflow <full|simple>      ワークフローモード (env: GHPP_WORKFLOW, default: full)
   --stale-threshold <duration>  降格対象とみなす滞留期間 (env: GHPP_STALE_THRESHOLD, default: 2h)
   --dry-run                     実際には更新せずに降格対象を表示する
 ```
+
+`--workflow=simple` を指定した場合、stale な doing は `Backlog`（inbox）に降格する（`full` モードでは `Ready`）。
 
 ## ビルド・実行
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,10 @@ const (
 	DefaultPlanLimit      = 3
 	DefaultStaleThreshold = 2 * time.Hour
 	DefaultPlannedLabel   = "planned"
+
+	WorkflowFull    = "full"
+	WorkflowSimple  = "simple"
+	DefaultWorkflow = WorkflowFull
 )
 
 // getEnvOrDefault returns the value of the environment variable named by the key,
@@ -42,6 +46,7 @@ type Config struct {
 	PromotePlanEnabled  bool
 	PromoteReadyEnabled bool
 	PlannedLabel        string
+	Workflow            string
 }
 
 // Load reads environment variables and returns a Config.
@@ -69,6 +74,7 @@ func LoadWithArgs(args []string) (*Config, error) {
 	promotePlanEnabled := fs.Bool("promote-plan-enabled", true, "Enable backlog→plan auto-promotion (env: GHPP_PROMOTE_PLAN_ENABLED, default: true)")
 	promoteReadyEnabled := fs.Bool("promote-ready-enabled", false, "Enable plan→ready auto-promotion (env: GHPP_PROMOTE_READY_ENABLED, default: false)")
 	plannedLabel := fs.String("planned-label", "", "Label name that triggers plan→ready promotion (env: GHPP_PLANNED_LABEL, default: planned)")
+	workflow := fs.String("workflow", "", "Workflow mode: full or simple (env: GHPP_WORKFLOW, default: full)")
 
 	if args != nil {
 		if err := fs.Parse(args); err != nil {
@@ -173,6 +179,12 @@ func LoadWithArgs(args []string) (*Config, error) {
 		return nil, fmt.Errorf("failed to load config: --planned-label (or GHPP_PLANNED_LABEL) must not be empty when --promote-ready-enabled is true")
 	}
 
+	// Resolve workflow (flag > env > default "full")
+	resolvedWorkflow := resolve("workflow", *workflow, "GHPP_WORKFLOW", DefaultWorkflow)
+	if resolvedWorkflow != WorkflowFull && resolvedWorkflow != WorkflowSimple {
+		return nil, fmt.Errorf("failed to load config: --workflow must be one of [%s, %s], got %q", WorkflowFull, WorkflowSimple, resolvedWorkflow)
+	}
+
 	return &Config{
 		Token:               resolvedToken,
 		Owner:               resolvedOwner,
@@ -187,5 +199,6 @@ func LoadWithArgs(args []string) (*Config, error) {
 		PromotePlanEnabled:  resolvedPromotePlanEnabled,
 		PromoteReadyEnabled: resolvedPromoteReadyEnabled,
 		PlannedLabel:        resolvedPlannedLabel,
+		Workflow:            resolvedWorkflow,
 	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -12,6 +13,7 @@ var allEnvKeys = []string{
 	"GHPP_PLAN_LIMIT",
 	"GHPP_PROMOTE_PLAN_ENABLED",
 	"GHPP_PROMOTE_READY_ENABLED", "GHPP_PLANNED_LABEL",
+	"GHPP_WORKFLOW",
 }
 
 // clearEnv clears all config-related environment variables for test isolation.
@@ -52,6 +54,7 @@ func TestLoad(t *testing.T) {
 				PlanLimit:          5,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 		{
@@ -72,6 +75,7 @@ func TestLoad(t *testing.T) {
 				PlanLimit:          3,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 		{
@@ -170,6 +174,7 @@ func TestLoadWithArgs(t *testing.T) {
 				PlanLimit:          7,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 		{
@@ -196,6 +201,7 @@ func TestLoadWithArgs(t *testing.T) {
 				PlanLimit:          4,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 		{
@@ -227,6 +233,7 @@ func TestLoadWithArgs(t *testing.T) {
 				PlanLimit:          10,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 		{
@@ -275,6 +282,7 @@ func TestLoadWithArgs(t *testing.T) {
 				PlanLimit:          DefaultPlanLimit,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 		{
@@ -299,6 +307,7 @@ func TestLoadWithArgs(t *testing.T) {
 				DryRun:             true,
 				PromotePlanEnabled: true,
 				PlannedLabel:       DefaultPlannedLabel,
+				Workflow:           WorkflowFull,
 			},
 		},
 	}
@@ -364,6 +373,9 @@ func assertConfig(t *testing.T, got, want *Config) {
 	if got.PlannedLabel != want.PlannedLabel {
 		t.Errorf("PlannedLabel = %q, want %q", got.PlannedLabel, want.PlannedLabel)
 	}
+	if got.Workflow != want.Workflow {
+		t.Errorf("Workflow = %q, want %q", got.Workflow, want.Workflow)
+	}
 }
 
 func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
@@ -397,6 +409,7 @@ func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: true,
 				PlannedLabel:        "planned",
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -423,6 +436,7 @@ func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: true,
 				PlannedLabel:        "my-label",
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -451,6 +465,7 @@ func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        "flag-label",
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -474,6 +489,7 @@ func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -523,6 +539,7 @@ func TestLoadWithArgs_PromoteReadyEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        "custom-label",
+				Workflow:            WorkflowFull,
 			},
 		},
 	}
@@ -579,6 +596,7 @@ func TestLoadWithArgs_PromotePlanEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -603,6 +621,7 @@ func TestLoadWithArgs_PromotePlanEnabled(t *testing.T) {
 				PromotePlanEnabled:  false,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -628,6 +647,7 @@ func TestLoadWithArgs_PromotePlanEnabled(t *testing.T) {
 				PromotePlanEnabled:  false,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -653,6 +673,7 @@ func TestLoadWithArgs_PromotePlanEnabled(t *testing.T) {
 				PromotePlanEnabled:  true,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -679,6 +700,7 @@ func TestLoadWithArgs_PromotePlanEnabled(t *testing.T) {
 				PromotePlanEnabled:  false,
 				PromoteReadyEnabled: false,
 				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
 			},
 		},
 		{
@@ -706,6 +728,199 @@ func TestLoadWithArgs_PromotePlanEnabled(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertConfig(t, got, tt.want)
+		})
+	}
+}
+
+func TestLoadWithArgs_Workflow(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		env     map[string]string
+		want    *Config
+		wantErr bool
+	}{
+		{
+			name: "default: workflow=full",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromotePlanEnabled:  true,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
+			},
+		},
+		{
+			name: "--workflow=full explicit",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--workflow", "full",
+			},
+			env: map[string]string{},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromotePlanEnabled:  true,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
+			},
+		},
+		{
+			name: "--workflow=simple flag",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--workflow", "simple",
+			},
+			env: map[string]string{},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromotePlanEnabled:  true,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowSimple,
+			},
+		},
+		{
+			name: "GHPP_WORKFLOW=simple env var",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{
+				"GHPP_WORKFLOW": "simple",
+			},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromotePlanEnabled:  true,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowSimple,
+			},
+		},
+		{
+			name: "flag overrides env var for workflow",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--workflow", "full",
+			},
+			env: map[string]string{
+				"GHPP_WORKFLOW": "simple",
+			},
+			want: &Config{
+				Token:               "tok",
+				Owner:               "owner",
+				ProjectNumber:       1,
+				StatusInbox:         DefaultStatusInbox,
+				StatusPlan:          DefaultStatusPlan,
+				StatusReady:         DefaultStatusReady,
+				StatusDoing:         DefaultStatusDoing,
+				PlanLimit:           DefaultPlanLimit,
+				StaleThreshold:      DefaultStaleThreshold,
+				PromotePlanEnabled:  true,
+				PromoteReadyEnabled: false,
+				PlannedLabel:        DefaultPlannedLabel,
+				Workflow:            WorkflowFull,
+			},
+		},
+		{
+			name: "--workflow=invalid returns error",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+				"--workflow", "light",
+			},
+			env:     map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "GHPP_WORKFLOW=invalid returns error",
+			args: []string{
+				"--token", "tok",
+				"--owner", "owner",
+				"--project-number", "1",
+			},
+			env: map[string]string{
+				"GHPP_WORKFLOW": "invalid",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			got, err := LoadWithArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if got != nil {
+					t.Errorf("expected nil config on error, got %+v", got)
+				}
+				// error message must list allowed values
+				if err != nil {
+					msg := err.Error()
+					if !strings.Contains(msg, "full") || !strings.Contains(msg, "simple") {
+						t.Errorf("error message %q should list allowed workflow values", msg)
+					}
 				}
 				return
 			}

--- a/internal/demote/demote.go
+++ b/internal/demote/demote.go
@@ -61,6 +61,12 @@ func buildPhaseResult(results github.DemotePhaseResults) github.DemotePhaseResul
 func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, demoter github.ItemPromoter, now time.Time) (github.DemotePhaseResults, error) {
 	var results github.DemotePhaseResults
 
+	// 降格先: full モードでは Ready、simple モードでは Backlog
+	toStatus := cfg.StatusReady
+	if cfg.Workflow == config.WorkflowSimple {
+		toStatus = cfg.StatusInbox
+	}
+
 	for _, item := range items {
 		if item.Status != cfg.StatusDoing {
 			continue
@@ -75,8 +81,8 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 		}
 
 		if !cfg.DryRun {
-			if err := demoter.UpdateItemStatus(ctx, meta, item.ID, cfg.StatusReady); err != nil {
-				return results, fmt.Errorf("failed to demote item %s to %s: %w", item.ID, cfg.StatusReady, err)
+			if err := demoter.UpdateItemStatus(ctx, meta, item.ID, toStatus); err != nil {
+				return results, fmt.Errorf("failed to demote item %s to %s: %w", item.ID, toStatus, err)
 			}
 		}
 
@@ -84,7 +90,7 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 			Item:       item,
 			Key:        urlutil.ExtractKey(item.URL, "doing"),
 			FromStatus: cfg.StatusDoing,
-			ToStatus:   cfg.StatusReady,
+			ToStatus:   toStatus,
 		})
 	}
 

--- a/internal/demote/demote_test.go
+++ b/internal/demote/demote_test.go
@@ -60,7 +60,14 @@ func defaultCfg() *config.Config {
 		StatusDoing:    "In progress",
 		StaleThreshold: 2 * time.Hour,
 		DryRun:         false,
+		Workflow:       config.WorkflowFull,
 	}
+}
+
+func simpleCfg() *config.Config {
+	cfg := defaultCfg()
+	cfg.Workflow = config.WorkflowSimple
+	return cfg
 }
 
 // staleTime は Status 遷移から stale 閾値（2h）を超えた時刻を返す。
@@ -244,5 +251,91 @@ func TestRun_FetchMetaError(t *testing.T) {
 	_, err := Run(context.Background(), cfg, nil, md)
 	if err == nil {
 		t.Fatal("expected error but got nil")
+	}
+}
+
+// TestDoingPhase_Simple_StaleItemDemotedToBacklog: simple モードで stale な doing が Backlog に降格
+func TestDoingPhase_Simple_StaleItemDemotedToBacklog(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	demoted := resp.Phases.Doing.Results.Demoted
+	if len(demoted) != 1 {
+		t.Fatalf("expected 1 demoted, got %d", len(demoted))
+	}
+	if demoted[0].FromStatus != "In progress" {
+		t.Errorf("FromStatus = %q, want %q", demoted[0].FromStatus, "In progress")
+	}
+	if demoted[0].ToStatus != "Backlog" {
+		t.Errorf("ToStatus = %q, want %q", demoted[0].ToStatus, "Backlog")
+	}
+	if len(md.updated) != 1 {
+		t.Fatalf("expected 1 UpdateItemStatus call, got %d", len(md.updated))
+	}
+	if md.updated[0].StatusName != "Backlog" {
+		t.Errorf("UpdateItemStatus called with %q, want %q", md.updated[0].StatusName, "Backlog")
+	}
+}
+
+// TestDoingPhase_Simple_FreshItemSkipped: simple モードでも fresh はスキップ
+func TestDoingPhase_Simple_FreshItemSkipped(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Fresh Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: freshTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Phases.Doing.Results.Demoted) != 0 {
+		t.Fatalf("expected 0 demoted, got %d", len(resp.Phases.Doing.Results.Demoted))
+	}
+	if len(resp.Phases.Doing.Results.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(resp.Phases.Doing.Results.Skipped))
+	}
+	if len(md.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(md.updated))
+	}
+}
+
+// TestDoingPhase_Simple_DryRun: simple モードでも DryRun が機能
+func TestDoingPhase_Simple_DryRun(t *testing.T) {
+	md := &mockDemoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	cfg.DryRun = true
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Stale Doing", URL: "https://github.com/owner/repo/issues/1", Status: "In progress", UpdatedAt: staleTime(), Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(md.updated) != 0 {
+		t.Errorf("dry-run: expected 0 UpdateItemStatus calls, got %d", len(md.updated))
+	}
+	// dry-run でも demoted に記録される
+	demoted := resp.Phases.Doing.Results.Demoted
+	if len(demoted) != 1 {
+		t.Fatalf("expected 1 demoted (dry-run), got %d", len(demoted))
+	}
+	// ToStatus は Backlog
+	if demoted[0].ToStatus != "Backlog" {
+		t.Errorf("ToStatus = %q, want %q", demoted[0].ToStatus, "Backlog")
+	}
+	if !resp.DryRun {
+		t.Error("expected DryRun = true, got false")
 	}
 }

--- a/internal/promote/promote.go
+++ b/internal/promote/promote.go
@@ -16,6 +16,32 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, pr
 		return nil, fmt.Errorf("failed to fetch project meta: %w", err)
 	}
 
+	// simple モード: Backlog → In progress に直接昇格。plan / ready フェーズはスキップする
+	if cfg.Workflow == config.WorkflowSimple {
+		doingResults, err := doingPhase(ctx, cfg, items, meta, promoter, cfg.StatusInbox)
+		if err != nil {
+			return nil, fmt.Errorf("doing phase failed: %w", err)
+		}
+
+		planPhaseResult := buildPhaseResult(github.PhaseResults{})
+		readyPhaseResult := buildPhaseResult(github.PhaseResults{})
+		doingPhaseResult := buildPhaseResult(doingResults)
+
+		return &github.PromoteResponse{
+			DryRun: cfg.DryRun,
+			Summary: github.PhaseSummary{
+				Promoted: doingPhaseResult.Summary.Promoted,
+				Skipped:  doingPhaseResult.Summary.Skipped,
+				Total:    doingPhaseResult.Summary.Total,
+			},
+			Phases: github.PromotePhases{
+				Plan:  planPhaseResult,
+				Ready: readyPhaseResult,
+				Doing: doingPhaseResult,
+			},
+		}, nil
+	}
+
 	planResults, err := planPhase(ctx, cfg, items, meta, promoter)
 	if err != nil {
 		return nil, fmt.Errorf("plan phase failed: %w", err)
@@ -33,7 +59,7 @@ func Run(ctx context.Context, cfg *config.Config, items []github.ProjectItem, pr
 	itemsAfterReady := applyPromotions(itemsAfterPlan, readyResults.Promoted, cfg.StatusReady)
 
 	// itemsAfterReady には ready フェーズで昇格済みのアイテムも Ready ステータスとして含まれており、doing フェーズでカスケード昇格される
-	doingResults, err := doingPhase(ctx, cfg, itemsAfterReady, meta, promoter)
+	doingResults, err := doingPhase(ctx, cfg, itemsAfterReady, meta, promoter, cfg.StatusReady)
 	if err != nil {
 		return nil, fmt.Errorf("doing phase failed: %w", err)
 	}
@@ -187,7 +213,7 @@ func hasLabel(labels []string, target string) bool {
 	return false
 }
 
-func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter) (github.PhaseResults, error) {
+func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectItem, meta *github.ProjectMeta, promoter github.ItemPromoter, sourceStatus string) (github.PhaseResults, error) {
 	var results github.PhaseResults
 
 	// Build set of repos that already have a doing item.
@@ -203,7 +229,7 @@ func doingPhase(ctx context.Context, cfg *config.Config, items []github.ProjectI
 	}
 
 	for _, item := range items {
-		if item.Status != cfg.StatusReady {
+		if item.Status != sourceStatus {
 			continue
 		}
 

--- a/internal/promote/promote_test.go
+++ b/internal/promote/promote_test.go
@@ -61,7 +61,14 @@ func defaultCfg() *config.Config {
 		StatusDoing:        "In progress",
 		PlanLimit:          0,
 		PromotePlanEnabled: true,
+		Workflow:           config.WorkflowFull,
 	}
+}
+
+func simpleCfg() *config.Config {
+	cfg := defaultCfg()
+	cfg.Workflow = config.WorkflowSimple
+	return cfg
 }
 
 func TestPlanPhase_InboxToPlan(t *testing.T) {
@@ -907,5 +914,228 @@ func TestRun_PlanFieldAlwaysPresent(t *testing.T) {
 	}
 	if resp.Phases.Plan.Results.Skipped == nil {
 		t.Error("phases.plan.results.skipped should not be nil even when disabled")
+	}
+}
+
+// TestRun_Simple_BacklogToDoing: simple モードで Backlog の item が直接 In progress に昇格する
+func TestRun_Simple_BacklogToDoing(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Backlog Issue", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Doing.Results.Promoted
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if promoted[0].Item.ID != "1" {
+		t.Errorf("promoted item ID = %q, want %q", promoted[0].Item.ID, "1")
+	}
+	if promoted[0].ToStatus != "In progress" {
+		t.Errorf("ToStatus = %q, want %q", promoted[0].ToStatus, "In progress")
+	}
+	if promoted[0].Key != "doing-owner-repo-a-1" {
+		t.Errorf("Key = %q, want %q", promoted[0].Key, "doing-owner-repo-a-1")
+	}
+	// UpdateItemStatus が "In progress" で呼ばれること
+	if len(mp.updated) != 1 {
+		t.Fatalf("expected 1 UpdateItemStatus call, got %d", len(mp.updated))
+	}
+	if mp.updated[0].StatusName != "In progress" {
+		t.Errorf("UpdateItemStatus called with %q, want %q", mp.updated[0].StatusName, "In progress")
+	}
+	if mp.updated[0].ItemID != "1" {
+		t.Errorf("UpdateItemStatus called with itemID %q, want %q", mp.updated[0].ItemID, "1")
+	}
+}
+
+// TestRun_Simple_PlanReadySkipped: simple モードで Plan/Ready の item は doing フェーズの取り込み対象外
+func TestRun_Simple_PlanReadySkipped(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	items := []github.ProjectItem{
+		{ID: "p", Title: "Plan", URL: "https://github.com/owner/repo-a/issues/1", Status: "Plan", Labels: []string{"planned"}},
+		{ID: "r", Title: "Ready", URL: "https://github.com/owner/repo-b/issues/1", Status: "Ready", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Phases.Doing.Results.Promoted) != 0 {
+		t.Errorf("expected 0 promoted, got %d", len(resp.Phases.Doing.Results.Promoted))
+	}
+	if len(resp.Phases.Doing.Results.Skipped) != 0 {
+		t.Errorf("expected 0 skipped, got %d", len(resp.Phases.Doing.Results.Skipped))
+	}
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+}
+
+// TestRun_Simple_SameRepoLimit: simple モードでも「1 リポジトリ1件」ルールが効く
+func TestRun_Simple_SameRepoLimit(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Backlog 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Backlog 2", URL: "https://github.com/owner/repo-a/issues/2", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promoted := resp.Phases.Doing.Results.Promoted
+	skipped := resp.Phases.Doing.Results.Skipped
+	if len(promoted) != 1 {
+		t.Fatalf("expected 1 promoted, got %d", len(promoted))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+	if skipped[0].Reason != "repository already has doing issue" {
+		t.Errorf("Reason = %q, want %q", skipped[0].Reason, "repository already has doing issue")
+	}
+}
+
+// TestRun_Simple_ExistingDoing: simple モードで既に doing 中の repo の Backlog はスキップされる
+func TestRun_Simple_ExistingDoing(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	items := []github.ProjectItem{
+		{ID: "d", Title: "Doing", URL: "https://github.com/owner/repo-a/issues/1", Status: "In progress", Labels: []string{}},
+		{ID: "b", Title: "Backlog", URL: "https://github.com/owner/repo-a/issues/2", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Phases.Doing.Results.Promoted) != 0 {
+		t.Errorf("expected 0 promoted, got %d", len(resp.Phases.Doing.Results.Promoted))
+	}
+	skipped := resp.Phases.Doing.Results.Skipped
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(skipped))
+	}
+	if skipped[0].Item.ID != "b" {
+		t.Errorf("skipped item ID = %q, want %q", skipped[0].Item.ID, "b")
+	}
+}
+
+// TestRun_Simple_PromoteFlagsIgnored: simple モードで promote-plan-enabled / promote-ready-enabled の値が挙動に影響しない
+func TestRun_Simple_PromoteFlagsIgnored(t *testing.T) {
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Backlog", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog", Labels: []string{"planned"}},
+		{ID: "2", Title: "Plan", URL: "https://github.com/owner/repo-b/issues/1", Status: "Plan", Labels: []string{"planned"}},
+	}
+
+	// パターン1: PromotePlanEnabled=true, PromoteReadyEnabled=false
+	mp1 := &mockPromoter{meta: defaultMeta}
+	cfg1 := simpleCfg()
+	cfg1.PromotePlanEnabled = true
+	cfg1.PromoteReadyEnabled = false
+	cfg1.PlannedLabel = "planned"
+	resp1, err := Run(context.Background(), cfg1, items, mp1)
+	if err != nil {
+		t.Fatalf("unexpected error (pattern 1): %v", err)
+	}
+
+	// パターン2: PromotePlanEnabled=false, PromoteReadyEnabled=true
+	mp2 := &mockPromoter{meta: defaultMeta}
+	cfg2 := simpleCfg()
+	cfg2.PromotePlanEnabled = false
+	cfg2.PromoteReadyEnabled = true
+	cfg2.PlannedLabel = "planned"
+	resp2, err := Run(context.Background(), cfg2, items, mp2)
+	if err != nil {
+		t.Fatalf("unexpected error (pattern 2): %v", err)
+	}
+
+	// 両パターンで結果が同一であること（フラグが silently 無視される）
+	if resp1.Summary != resp2.Summary {
+		t.Errorf("summary differs: %+v vs %+v", resp1.Summary, resp2.Summary)
+	}
+	if len(mp1.updated) != len(mp2.updated) {
+		t.Errorf("UpdateItemStatus call count differs: %d vs %d", len(mp1.updated), len(mp2.updated))
+	}
+	// どちらのパターンでも Backlog のみ昇格対象（Plan は触らない）
+	if len(mp1.updated) != 1 {
+		t.Errorf("pattern 1: expected 1 update call, got %d", len(mp1.updated))
+	}
+	if mp1.updated[0].ItemID != "1" {
+		t.Errorf("pattern 1: updated ItemID = %q, want %q", mp1.updated[0].ItemID, "1")
+	}
+}
+
+// TestRun_Simple_DryRun: simple モードでも DryRun が機能する
+func TestRun_Simple_DryRun(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := simpleCfg()
+	cfg.DryRun = true
+	items := []github.ProjectItem{
+		{ID: "1", Title: "Backlog 1", URL: "https://github.com/owner/repo-a/issues/1", Status: "Backlog", Labels: []string{}},
+		{ID: "2", Title: "Backlog 2", URL: "https://github.com/owner/repo-b/issues/1", Status: "Backlog", Labels: []string{}},
+	}
+
+	resp, err := Run(context.Background(), cfg, items, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mp.updated) != 0 {
+		t.Errorf("expected 0 UpdateItemStatus calls, got %d", len(mp.updated))
+	}
+	if len(resp.Phases.Doing.Results.Promoted) != 2 {
+		t.Errorf("expected 2 promoted in output, got %d", len(resp.Phases.Doing.Results.Promoted))
+	}
+	if !resp.DryRun {
+		t.Error("expected DryRun = true, got false")
+	}
+}
+
+// TestRun_Simple_PlanReadyEmptyResults: simple モードでも phases.plan / phases.ready は空配列で存在する
+func TestRun_Simple_PlanReadyEmptyResults(t *testing.T) {
+	mp := &mockPromoter{meta: defaultMeta}
+	cfg := simpleCfg()
+
+	resp, err := Run(context.Background(), cfg, []github.ProjectItem{}, mp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Phases.Plan.Results.Promoted == nil {
+		t.Error("phases.plan.results.promoted should not be nil")
+	}
+	if resp.Phases.Plan.Results.Skipped == nil {
+		t.Error("phases.plan.results.skipped should not be nil")
+	}
+	if resp.Phases.Ready.Results.Promoted == nil {
+		t.Error("phases.ready.results.promoted should not be nil")
+	}
+	if resp.Phases.Ready.Results.Skipped == nil {
+		t.Error("phases.ready.results.skipped should not be nil")
+	}
+	if len(resp.Phases.Plan.Results.Promoted) != 0 {
+		t.Errorf("plan promoted len = %d, want 0", len(resp.Phases.Plan.Results.Promoted))
+	}
+	if len(resp.Phases.Plan.Results.Skipped) != 0 {
+		t.Errorf("plan skipped len = %d, want 0", len(resp.Phases.Plan.Results.Skipped))
+	}
+	if len(resp.Phases.Ready.Results.Promoted) != 0 {
+		t.Errorf("ready promoted len = %d, want 0", len(resp.Phases.Ready.Results.Promoted))
+	}
+	if len(resp.Phases.Ready.Results.Skipped) != 0 {
+		t.Errorf("ready skipped len = %d, want 0", len(resp.Phases.Ready.Results.Skipped))
 	}
 }


### PR DESCRIPTION
Closes #58

## 変更内容

`--workflow=full|simple` フラグおよび環境変数 `GHPP_WORKFLOW` を導入し、シンプルなプロジェクト（Backlog → In progress の2ステータスのみ）にも対応できるようにした。デフォルトは `full` で後方互換を維持。

### モード別挙動

| 項目 | full (default) | simple |
|------|----------------|--------|
| 自動遷移 | Backlog → Plan、Ready → In progress（Plan → Ready は \`planned\` ラベルゲート） | Backlog → In progress |
| \`--promote-plan-enabled\` / \`--promote-ready-enabled\` | 有効 | silently 無視 |
| stale demote 先 | In progress → Ready | In progress → Backlog |
| 「1 リポジトリ1件」ルール（doing フェーズ） | 維持 | 維持 |

### 主な変更ファイル

- \`internal/config/config.go\` / \`config_test.go\`: \`Workflow\` フィールド・定数・バリデーション追加
- \`internal/promote/promote.go\` / \`promote_test.go\`: simple モード分岐、\`doingPhase\` に \`sourceStatus\` 引数を追加
- \`internal/demote/demote.go\` / \`demote_test.go\`: simple モード時の降格先を \`StatusInbox\` に切替
- \`docs/business/model.md\`、\`docs/business/overview.md\`、\`docs/development/guideline.md\`、\`README.md\`: 2モード仕様を追記

### 検証

- 156 tests / 9 packages すべてパス
- \`go vet\` clean、\`gofmt -l\` empty、\`go build ./...\` 成功
- 計画の検証必須事項 V1〜V9 すべてパス